### PR TITLE
Added default empty constructor to work with less permissive gcc 4.6 settings

### DIFF
--- a/include/cukebins/internal/step/StepManager.hpp
+++ b/include/cukebins/internal/step/StepManager.hpp
@@ -54,7 +54,9 @@ class InvokeArgs {
     typedef std::vector<std::string> args_type;
 public:
     typedef args_type::size_type size_type;
-
+    
+    InvokeArgs() { }
+ 
     void addArg(const std::string arg);
     Table & getVariableTableArg();
 


### PR DESCRIPTION
Added default empty constructor to const class cukebins::internal::InvokeArgs

The gcc 4.6.0 on Fedora 15 was issuing the following error: 'const class
cukebins::internal::InvokeArgs' has no user-provided default
constructor. Fixed by added a default (empty) constructor.

This was due to the initialized static const InvokeArgs NO_INVOKE_ARGS in DriverTestRunner.hpp, line 51.
