### PR TITLE
Fixes for issue #51 visible on some systems.

### DIFF
--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -58,7 +58,7 @@ private:
 
 public:
     StepMatchesResponse(const std::vector<StepMatch> & matchingSteps);
-    const std::vector<StepMatch> getMatchingSteps() const;
+    const std::vector<StepMatch>& getMatchingSteps() const;
 
     void accept(WireResponseVisitor *visitor) const;
 };

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -39,7 +39,7 @@ class MatchResult {
 public:
     typedef std::vector<SingleStepMatch> match_results_type;
 
-    const match_results_type getResultSet();
+    const match_results_type& getResultSet();
     void addMatch(SingleStepMatch match);
 
     operator void *();

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -48,7 +48,7 @@ MatchResult::operator bool() {
     return !resultSet.empty();
 }
 
-const MatchResult::match_results_type MatchResult::getResultSet() {
+const MatchResult::match_results_type& MatchResult::getResultSet() {
     return resultSet;
 }
 

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -60,7 +60,7 @@ StepMatchesResponse::StepMatchesResponse(const std::vector<StepMatch> & matching
     : matchingSteps(matchingSteps) {
 }
 
-const std::vector<StepMatch> StepMatchesResponse::getMatchingSteps() const {
+const std::vector<StepMatch>& StepMatchesResponse::getMatchingSteps() const {
     return matchingSteps;
 }
 


### PR DESCRIPTION
For example crashes (segv) occurred on:
- One of the automatic tests: 37 - WireMessageCodecTest.handlesStepMatchesResponse (SEGFAULT)
- Calc example (while running features)
