### PR TITLE
A number of fixes to compile with VS2012 and Xcode5

### DIFF
--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -35,7 +35,7 @@ class BeforeHook : public Hook {
 
 class AroundStepHook : public Hook {
 public:
-    virtual void invokeHook(Scenario *scenario, CallableStep *step);
+    virtual void invokeHookWithStep(Scenario *scenario, CallableStep *step);
     virtual void skipHook();
 protected:
     CallableStep *step;

--- a/include/cucumber-cpp/internal/hook/Tag.hpp
+++ b/include/cucumber-cpp/internal/hook/Tag.hpp
@@ -16,6 +16,7 @@ class TagExpression {
 public:
     typedef std::vector<std::string> tag_list;
 
+    virtual ~TagExpression() { }
     virtual bool matches(const tag_list &tags) = 0;
 };
 

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -62,6 +62,11 @@ public:
 
     template<class T> T getInvokeArg(size_type i) const;
     const Table & getTableArg() const;
+
+    size_type argsSize() const {
+      return args.size();
+    }
+
 private:
     Table tableArg;
     args_type args;

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -91,7 +91,7 @@ public:
 
     bool isSuccess() const;
     bool isPending() const;
-    const InvokeResultType getType() const;
+    InvokeResultType getType() const;
     const std::string &getDescription() const;
 };
 

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -157,7 +157,7 @@ protected:
 };
 
 
-static std::string toSourceString(const char *filePath, const int line) {
+static inline std::string toSourceString(const char *filePath, const int line) {
     using namespace std;
     stringstream s;
     string file(filePath);

--- a/include/cucumber-cpp/internal/utils/Regex.hpp
+++ b/include/cucumber-cpp/internal/utils/Regex.hpp
@@ -1,7 +1,10 @@
 #ifndef CUKE_REGEX_HPP_
 #define CUKE_REGEX_HPP_
 
+#include <string>
 #include <vector>
+
+#define BOOST_REGEX_V4_CHAR_REGEX_TRAITS_HPP
 
 #include <boost/regex.hpp>
 

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -87,11 +87,11 @@ void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type &
     }
 }
 
-void CukeEngineImpl::endScenario(const tags_type & tags) {
+void CukeEngineImpl::endScenario(const tags_type & /*tags*/) {
     cukeCommands.endScenario();
 }
 
-std::string CukeEngineImpl::snippetText(const std::string & keyword, const std::string & name, const std::string & multilineArgClass) const {
+std::string CukeEngineImpl::snippetText(const std::string & keyword, const std::string & name, const std::string & /*multilineArgClass*/) const {
     return cukeCommands.snippetText(keyword, name);
 }
 

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -55,13 +55,13 @@ void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type &
 
         if (tableArg.shape()[0] > 1 && tableArg.shape()[1] > 0) {
             Table & commandTableArg = commandArgs.getVariableTableArg();
-            for (table_index j = 0; j < tableArg.shape()[1]; ++j) {
+            for (table_index j = 0; j < table_index(tableArg.shape()[1]); ++j) {
                 commandTableArg.addColumn(tableArg[0][j]);
             }
 
-            for (table_index i = 1; i < tableArg.shape()[0]; ++i) {
+            for (table_index i = 1; i < table_index(tableArg.shape()[0]); ++i) {
                 Table::row_type row;
-                for (table_index j = 0; j < tableArg.shape()[1]; ++j) {
+                for (table_index j = 0; j < table_index(tableArg.shape()[1]); ++j) {
                     row.push_back(tableArg[i][j]);
                 }
                 commandTableArg.addRow(row);

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -24,7 +24,7 @@ bool Hook::tagsMatch(Scenario *scenario) {
     return !scenario || tagExpression->matches(scenario->getTags());
 }
 
-void AroundStepHook::invokeHook(Scenario *scenario, CallableStep *step) {
+void AroundStepHook::invokeHookWithStep(Scenario *scenario, CallableStep *step) {
     this->step = step;
     Hook::invokeHook(scenario);
 }
@@ -155,7 +155,7 @@ void StepCallChain::execNext() {
     } else {
         HookRegistrar::aroundhook_list_type::iterator currentHook = nextHook++;
         CallableStepChain callableStepChain(this);
-        (*currentHook)->invokeHook(scenario, &callableStepChain);
+        (*currentHook)->invokeHookWithStep(scenario, &callableStepChain);
     }
 }
 

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -114,7 +114,7 @@ bool InvokeResult::isPending() const {
     return (type == PENDING);
 }
 
-const InvokeResultType InvokeResult::getType() const {
+InvokeResultType InvokeResult::getType() const {
     return type;
 }
 

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -257,7 +257,7 @@ namespace {
             return write_string(v, false);
         }
 
-        void visit(const SuccessResponse */*response*/) {
+        void visit(const SuccessResponse* /*response*/) {
             success();
         }
 

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -88,7 +88,8 @@ void SnippetTextResponse::accept(WireResponseVisitor *visitor) const {
 
 class CommandDecoder {
 public:
-    virtual WireCommand *decode(const mValue & jsonArgs) const = 0;
+  virtual ~CommandDecoder() { }
+  virtual WireCommand *decode(const mValue & jsonArgs) const = 0;
 };
 
 

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -256,7 +256,7 @@ namespace {
             return write_string(v, false);
         }
 
-        void visit(const SuccessResponse *response) {
+        void visit(const SuccessResponse */*response*/) {
             success();
         }
 

--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -71,7 +71,7 @@ WireResponse *SnippetTextCommand::run(CukeEngine *engine) const {
 }
 
 
-WireResponse *FailingCommand::run(CukeEngine *engine) const {
+WireResponse *FailingCommand::run(CukeEngine* /*engine*/) const {
     return new FailureResponse;
 }
 

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -4,9 +4,9 @@ namespace cucumber {
 namespace internal {
 
 SocketServer::SocketServer(const ProtocolHandler *protocolHandler) :
+    protocolHandler(protocolHandler),
     ios(),
-    acceptor(ios),
-    protocolHandler(protocolHandler) {
+    acceptor(ios) {
 }
 
 void SocketServer::listen(const port_type port) {

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -31,19 +31,19 @@ public:
     void reset();
 
     // Formatter
-    void log_start( std::ostream&, counter_t test_cases_amount) {};
+    void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
     void log_build_info( std::ostream&) {};
 
-    void test_unit_start( std::ostream&, test_unit const& tu) {};
-    void test_unit_finish( std::ostream&, test_unit const& tu, unsigned long elapsed) {};
-    void test_unit_skipped( std::ostream&, test_unit const& tu) {};
+    void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
+    void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};
+    void test_unit_skipped( std::ostream&, test_unit const& /*tu*/) {};
 
-    void log_exception( std::ostream&, log_checkpoint_data const&, execution_exception const& ex) {};
+    void log_exception( std::ostream&, log_checkpoint_data const&, execution_exception const& /*ex*/) {};
 
-    void log_entry_start( std::ostream&, log_entry_data const&, log_entry_types let) {};
-    void log_entry_value( std::ostream&, const_string value);
-    void log_entry_value( std::ostream&, lazy_ostream const& value) {};
+    void log_entry_start( std::ostream&, log_entry_data const&, log_entry_types /*let*/) {};
+    void log_entry_value( std::ostream&, const_string /*value*/);
+    void log_entry_value( std::ostream&, lazy_ostream const& /*value*/) {};
     void log_entry_finish( std::ostream&) {};
 
     void log_exception(std::ostream&, const boost::unit_test::log_checkpoint_data&, boost::unit_test::const_string) {};

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -15,13 +15,18 @@ namespace internal {
 
 
 namespace {
-
-bool boost_test_init() {
+#ifdef BOOST_TEST_ALTERNATIVE_INIT_API
+  bool boost_init_unit_test() {
     return true;
-}
+  }
+#else
+  ::boost::unit_test::test_suite*
+  boost_init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
+    return NULL;
+  }
+#endif
 
-static CukeBoostLogInterceptor *logInterceptor = 0;
-
+  static CukeBoostLogInterceptor *logInterceptor = 0;
 }
 
 
@@ -83,7 +88,12 @@ void BoostStep::initBoostTest() {
     if (!framework::is_initialized()) {
         int argc = 2;
         char *argv[] = { (char *) "", (char *) "" };
-        framework::init(&boost_test_init, argc, argv);
+
+#ifdef BOOST_TEST_ALTERNATIVE_INIT_API
+        framework::init(&boost_init_unit_test, argc, argv);
+#else
+        framework::init(&boost_init_unit_test_suite, argc, argv);
+#endif
         logInterceptor = new CukeBoostLogInterceptor;
         ::boost::unit_test::unit_test_log.set_formatter(logInterceptor);
         ::boost::unit_test::unit_test_log.set_threshold_level(log_all_errors);

--- a/tests/utils/HookRegistrationFixture.hpp
+++ b/tests/utils/HookRegistrationFixture.hpp
@@ -54,7 +54,7 @@ public:
         EmptyCallableStep emptyStep;
         aroundhook_list_type &ash = aroundStepHooks();
         for (HookRegistrar::aroundhook_list_type::const_iterator h = ash.begin(); h != ash.end(); ++h) {
-            (*h)->invokeHook(scenario, &emptyStep);
+            (*h)->invokeHookWithStep(scenario, &emptyStep);
         }
     }
 };


### PR DESCRIPTION
I would like to propose a number of changes to 

  - fix compiler warnings when building with VS2012 and Xcode5
  - fix a compiler error when using newer versions of boost (tested against 1.53)

In addition I would suggest a small API extension to internal/Step/StepManager.hpp, which allows to access the number of arguments.

Thank you for considering.