### PR TITLE
use boost option parser for port

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,10 +40,6 @@ int main(int argc, char **argv) {
     }
 
     try {
-        if (argc > 1) {
-            std::string firstArg(argv[1]);
-            port = ::cucumber::internal::fromString<int>(firstArg);
-        }
         acceptWireProtocol(port);
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     
     boost::program_options::options_description optionDescription("Allowed options");
     optionDescription.add_options()
-        ("help", "this help message")
+        ("help", "help for cucumber-cpp")
         ("port", value<int>(), "listening port of wireserver")
         ;
     boost::program_options::variables_map optionVariableMap;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include <cucumber-cpp/internal/connectors/wire/WireServer.hpp>
 #include <cucumber-cpp/internal/connectors/wire/WireProtocol.hpp>
 #include <iostream>
+#include <boost/program_options.hpp>
+using boost::program_options::value;
 
 namespace {
 
@@ -18,8 +20,26 @@ void acceptWireProtocol(int port) {
 }
 
 int main(int argc, char **argv) {
+    
+    boost::program_options::options_description optionDescription("Allowed options");
+    optionDescription.add_options()
+        ("help", "this help message")
+        ("port", value<int>(), "listening port of wireserver")
+        ;
+    boost::program_options::variables_map optionVariableMap;
+    boost::program_options::store( boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);
+    boost::program_options::notify(optionVariableMap); 
+
+    if (optionVariableMap.count("help")) {
+        std::cout << optionDescription << std::endl;
+    }
+
+    int port = 3902;
+    if (optionVariableMap.count("port")) {
+       port = optionVariableMap["port"].as<int>();
+    }
+
     try {
-        int port = 3902;
         if (argc > 1) {
             std::string firstArg(argv[1]);
             port = ::cucumber::internal::fromString<int>(firstArg);


### PR DESCRIPTION
use boost option parser for port, 
so if the user use program options in his test, he will not be forced to use the port parameter  