### PR TITLE
Issue #75 : Make it easier to use cucumber-cpp as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CUKE_ENABLE_EXAMPLES OFF CACHE BOOL "Enable the examples")
 
 enable_testing()
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 #
 # Generic Compiler Flags
@@ -108,7 +108,10 @@ include_directories(${CUKE_INCLUDE_DIR})
 set(CUKE_LIBRARIES cucumber-cpp ${CUKE_EXTRA_LIBRARIES})
 
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(NOT CUKE_DISABLE_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()
 
 if(CUKE_ENABLE_EXAMPLES)
     add_subdirectory(examples)


### PR DESCRIPTION
Support add_subdirectory(cucumber-cpp cucumber-cpp)
Set NOT CUKE_DISABLE_UNIT_TESTS to leave out unit tests