### PR TITLE
FIX: Invalid submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "features/cucumber-tck"]
 	path = features/cucumber-tck
-	url = git://github.com/cucumber/cucumber-tck.git
+	url = git@github.com:cucumber/cucumber-tck.git


### PR DESCRIPTION
Hello,

Submodule cucumber-tck is referenced with an invalid URL. We are not able to fetch this submodule.

Thanks for your library
