### PR TITLE
CalcQt example not compiling in OS X with case-insensitive filesystem

### DIFF
--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -16,6 +16,6 @@ if(QT4_FOUND)
     endif()
 
     set(CALCQT_SOURCES src/CalcQt.cpp src/CalculatorWidget.cpp)
-    add_executable(calcqt ${CALCQT_SOURCES} ${CALCQT_HEADERS_MOC})
-    target_link_libraries(calcqt ${QT_LIBRARIES})
+    add_executable(CalcQtApp ${CALCQT_SOURCES} ${CALCQT_HEADERS_MOC})
+    target_link_libraries(CalcQtApp ${QT_LIBRARIES})
 endif()


### PR DESCRIPTION
In OS X with a case-insensitive filesystem the build process complains that there are no rules for `examples/CalcQt/CMakeFiles/CalcQt.dir/depend`. This happens because `CalcQt.dir` and `calcqt.dir` are seen by the filesystem as the same directory and one of the targets in [examples/CalcQt/CMakeLists.txt](https://github.com/cucumber/cucumber-cpp/blob/master/examples/CalcQt/CMakeLists.txt) is lots. The lines in question are: 

```
    set(CALCQT_SOURCES src/CalcQt.cpp src/CalculatorWidget.cpp)
    add_executable(calcqt ${CALCQT_SOURCES} ${CALCQT_HEADERS_MOC})
    target_link_libraries(calcqt ${QT_LIBRARIES})
endif()
```

Changing target `calcqt` to `CalcQtApp` solves the issue.