### PR TITLE
Fix OSX build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Weffc++")
-    # TODO: A better fix should handle ld's --as-needed flag 
+    # TODO: A better fix should handle ld's --as-needed flag
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")
 elseif(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX") # exclude M$ min/max macros
@@ -91,13 +91,13 @@ endif()
 if(NOT CUKE_DISABLE_GTEST)
     set(GMOCK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/gmock")
     find_package(GMock REQUIRED)
-    
+
     if(GMOCK_FOUND)
-        set(CUKE_GTEST_LIBRARIES 
+        set(CUKE_GTEST_LIBRARIES
             ${GTEST_BOTH_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT}
         )
-        set(CUKE_GMOCK_LIBRARIES 
+        set(CUKE_GMOCK_LIBRARIES
             ${GTEST_BOTH_LIBRARIES}
             ${GMOCK_BOTH_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT}
@@ -143,6 +143,7 @@ if(NOT CUKE_DISABLE_FUNCTIONAL)
         set(CUKE_FEATURES_TMP ${CMAKE_BINARY_DIR}/tmp)
         set(CUKE_TEST_FEATURES_DIR ${CUKE_FEATURES_TMP}/test_features)
         set(CUKE_DYNAMIC_CPP_STEPS ${CUKE_TEST_FEATURES_DIR}/step_definitions/cpp_steps.cpp)
+        string(REPLACE "/tmp" "${CMAKE_FILES_DIRECTORY}/functional-steps.dir/tmp" CUKE_DYNAMIC_CPP_STEPS_OBJ "${CUKE_DYNAMIC_CPP_STEPS}${CMAKE_CXX_OUTPUT_EXTENSION}")
 
         file(WRITE ${CUKE_DYNAMIC_CPP_STEPS})
         add_executable(functional-steps EXCLUDE_FROM_ALL ${CUKE_DYNAMIC_CPP_STEPS})
@@ -158,6 +159,7 @@ if(NOT CUKE_DISABLE_FUNCTIONAL)
                 TMP_DIR=${CUKE_FEATURES_TMP}
                 DYNAMIC_CPP_STEPS_SRC=${CUKE_DYNAMIC_CPP_STEPS}
                 DYNAMIC_CPP_STEPS_EXE=${CMAKE_BINARY_DIR}/functional-steps
+                DYNAMIC_CPP_STEPS_OBJ=${CUKE_DYNAMIC_CPP_STEPS_OBJ}
                 COMPILE_DYNAMIC_CPP_STEPS=${CUKE_COMPILE_DYNAMIC_CPP_STEPS}
                 ${ARGV1} ${ARGV2} ${ARGV3} ${ARGV4} ${ARGV5} ${ARGV6}
                 ${CUKE_FEATURES_DIR}
@@ -174,4 +176,3 @@ if(NOT CUKE_DISABLE_FUNCTIONAL)
     endif()
 
 endif()
-

--- a/features/step_definitions/cucumber_cpp_mappings.rb
+++ b/features/step_definitions/cucumber_cpp_mappings.rb
@@ -252,6 +252,7 @@ EOF
   TMP_DIR                      = ENV["TMP_DIR"]
   FEATURES_DIR                 = ENV["TEST_FEATURES_DIR"]
   STEP_DEFINITIONS_SRC         = ENV["DYNAMIC_CPP_STEPS_SRC"]
+  STEP_DEFINITIONS_OBJ         = ENV["DYNAMIC_CPP_STEPS_OBJ"]
   STEP_DEFINITIONS_EXE         = ENV["DYNAMIC_CPP_STEPS_EXE"]
   COMPILE_STEP_DEFINITIONS_CMD = ENV["COMPILE_DYNAMIC_CPP_STEPS"]
 
@@ -292,17 +293,23 @@ EOF
     create_wire_file
     run_cucumber_cpp
     run_cucumber_test_feature params
-    Process.kill(:SIGTERM, @steps_out.pid) # for when there are no scenarios
+    Process.kill :SIGTERM, @steps_out.pid # for when there are no scenarios
     Process.wait @steps_out.pid
   end
 
   def write_main_step_definitions_file
-    write_file(STEP_DEFINITIONS_SRC, @support_code);
+    write_file STEP_DEFINITIONS_SRC, @support_code
   end
 
   def compile_step_definitions
+    remove_step_definition_obj
     compiler_output = %x[ #{COMPILE_STEP_DEFINITIONS_CMD} ]
     expect($?.success?).to be_true, "Compilation failed!\n#{compiler_output}"
+  end
+
+  def remove_step_definition_obj
+    remove_file STEP_DEFINITIONS_OBJ
+  rescue Errno::ENOENT
   end
 
   def create_wire_file

--- a/features/step_definitions/cucumber_cpp_mappings.rb
+++ b/features/step_definitions/cucumber_cpp_mappings.rb
@@ -293,8 +293,6 @@ EOF
     create_wire_file
     run_cucumber_cpp
     run_cucumber_test_feature params
-    Process.kill :SIGTERM, @steps_out.pid # for when there are no scenarios
-    Process.wait @steps_out.pid
   end
 
   def write_main_step_definitions_file

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -5,3 +5,15 @@ Before do
   FileUtils.mkdir(featuresTmpSpace)
   FileUtils.touch("#{featuresTmpSpace}/cycle.log")
 end
+
+After do
+  # for when there are no scenarios
+  if @steps_out
+    begin
+      Process.kill :SIGTERM, @steps_out.pid
+      Process.wait @steps_out.pid
+    rescue Errno::ESRCH  # exited already
+    rescue Errno::ECHILD # killed before wait call
+    end
+  end
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,8 +1,7 @@
 Before do
   require 'fileutils'
   featuresTmpSpace = ENV["TMP_DIR"]
-  FileUtils.rm_rf(featuresTmpSpace) if Dir.exists?(featuresTmpSpace) 
+  FileUtils.rm_rf(featuresTmpSpace) if Dir.exists?(featuresTmpSpace)
   FileUtils.mkdir(featuresTmpSpace)
   FileUtils.touch("#{featuresTmpSpace}/cycle.log")
 end
-


### PR DESCRIPTION
Build fails on OSX because make does not understand that the step definition sources have changed between one scenario and the next, even when the entire directory is removed.

Couldn't find a cleaner way to fix it than to remove the object file before recompiling it.

Can't test it on Windows at the moment.