### PR TITLE
Use boost program_options to parse command line parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - libboost-system-dev
       - libboost-regex-dev
       - libboost-date-time-dev 
+      - libboost-program-options-dev
       - libboost-test-dev
       - google-mock
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
     set(BOOST_MIN_VERSION "1.40")
 endif()
 
-set(CUKE_CORE_BOOST_LIBS thread system regex date_time)
+set(CUKE_CORE_BOOST_LIBS thread system regex date_time program_options)
 if(NOT CUKE_DISABLE_BOOST_TEST)
     set(CUKE_TEST_BOOST_LIBS unit_test_framework)
 endif()
@@ -73,7 +73,7 @@ endif()
 
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
-    set(CUKE_EXTRA_LIBRARIES ${CUKE_EXTRA_LIBRARIES} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_DATE_TIME_LIBRARY})
+    set(CUKE_EXTRA_LIBRARIES ${CUKE_EXTRA_LIBRARIES} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 endif()
 
 #

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with [CPP].
 It relies on a few libraries:
 
 * [Boost](http://www.boost.org/) 1.40 or later.
-  Required libraries: *thread*, *system*, *regex*, and *date_time*.
+  Required libraries: *thread*, *system*, *regex*, *date_time* and *program_options*.
   Optional library for Boost Test driver: *test*.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.
   Optional for the GTest driver. By default downloaded and built by CMake.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocol.hpp>
 #include <iostream>
 #include <boost/program_options.hpp>
-using boost::program_options::value;
 
 namespace {
 
@@ -20,18 +19,18 @@ void acceptWireProtocol(int port) {
 }
 
 int main(int argc, char **argv) {
-    
+    using boost::program_options::value;
     boost::program_options::options_description optionDescription("Allowed options");
     optionDescription.add_options()
         ("help", "help for cucumber-cpp")
         ("port", value<int>(), "listening port of wireserver")
         ;
     boost::program_options::variables_map optionVariableMap;
-    boost::program_options::store( boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);
-    boost::program_options::notify(optionVariableMap); 
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);
+    boost::program_options::notify(optionVariableMap);
 
     if (optionVariableMap.count("help")) {
-        std::cout << optionDescription << std::endl;
+        std::cerr << optionDescription << std::endl;
     }
 
     int port = 3902;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,10 +40,6 @@ int main(int argc, char **argv) {
     }
 
     try {
-        if (argc > 1) {
-            std::string firstArg(argv[1]);
-            port = ::cucumber::internal::fromString<int>(firstArg);
-        }
         acceptWireProtocol(port);
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     
     boost::program_options::options_description optionDescription("Allowed options");
     optionDescription.add_options()
-        ("help", "this help message")
+        ("help", "help for cucumber-cpp")
         ("port", value<int>(), "listening port of wireserver")
         ;
     boost::program_options::variables_map optionVariableMap;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include <cucumber-cpp/internal/connectors/wire/WireServer.hpp>
 #include <cucumber-cpp/internal/connectors/wire/WireProtocol.hpp>
 #include <iostream>
+#include <boost/program_options.hpp>
+using boost::program_options::value;
 
 namespace {
 
@@ -18,8 +20,26 @@ void acceptWireProtocol(int port) {
 }
 
 int main(int argc, char **argv) {
+    
+    boost::program_options::options_description optionDescription("Allowed options");
+    optionDescription.add_options()
+        ("help", "this help message")
+        ("port", value<int>(), "listening port of wireserver")
+        ;
+    boost::program_options::variables_map optionVariableMap;
+    boost::program_options::store( boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);
+    boost::program_options::notify(optionVariableMap); 
+
+    if (optionVariableMap.count("help")) {
+        std::cout << optionDescription << std::endl;
+    }
+
+    int port = 3902;
+    if (optionVariableMap.count("port")) {
+       port = optionVariableMap["port"].as<int>();
+    }
+
     try {
-        int port = 3902;
         if (argc > 1) {
             std::string firstArg(argv[1]);
             port = ::cucumber::internal::fromString<int>(firstArg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,13 +6,15 @@
 
 namespace {
 
-void acceptWireProtocol(int port) {
+void acceptWireProtocol(int port, bool verbose) {
     using namespace ::cucumber::internal;
     CukeEngineImpl cukeEngine;
     JsonSpiritWireMessageCodec wireCodec;
     WireProtocolHandler protocolHandler(&wireCodec, &cukeEngine);
     SocketServer server(&protocolHandler);
     server.listen(port);
+    if (verbose)
+        std::clog << "Listening on port " << port << std::endl;
     server.acceptOnce();
 }
 
@@ -22,8 +24,9 @@ int main(int argc, char **argv) {
     using boost::program_options::value;
     boost::program_options::options_description optionDescription("Allowed options");
     optionDescription.add_options()
-        ("help", "help for cucumber-cpp")
-        ("port", value<int>(), "listening port of wireserver")
+        ("help,h", "help for cucumber-cpp")
+        ("verbose,v", "verbose output")
+        ("port,p", value<int>(), "listening port of wireserver")
         ;
     boost::program_options::variables_map optionVariableMap;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);
@@ -31,15 +34,21 @@ int main(int argc, char **argv) {
 
     if (optionVariableMap.count("help")) {
         std::cerr << optionDescription << std::endl;
+        exit(1);
     }
 
     int port = 3902;
     if (optionVariableMap.count("port")) {
-       port = optionVariableMap["port"].as<int>();
+        port = optionVariableMap["port"].as<int>();
+    }
+
+    bool verbose = false;
+    if (optionVariableMap.count("verbose")) {
+        verbose = true;
     }
 
     try {
-        acceptWireProtocol(port);
+        acceptWireProtocol(port, verbose);
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;
         exit(1);


### PR DESCRIPTION
Based on PR #73 but modified to fix build script and add verbose option.