### PR TITLE
Upgrade Ruby libraries to more recent versions (not latest)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'cucumber', "=1.3.20"
-  gem 'aruba', "=0.6.1"
-  gem 'rspec', "=2.14.1"
+  gem 'cucumber', "=2.0.0"
+  gem 'aruba', "=0.8.0"
+  gem 'rspec', "=3.4.0"
 end
 

--- a/features/step_definitions/cucumber_cpp_mappings.rb
+++ b/features/step_definitions/cucumber_cpp_mappings.rb
@@ -172,36 +172,34 @@ EOF
   end
 
   def assert_world_variable_held_value_at_time(value, time)
-    check_exact_file_content "#{WORLD_VARIABLE_LOG_FILE}.#{time}", value
+    expect("#{WORLD_VARIABLE_LOG_FILE}.#{time}").to have_file_content(value)
   end
 
   def assert_world_function_called
-    check_file_presence [WORLD_FUNCTION_LOG_FILE], true
+    expect(WORLD_FUNCTION_LOG_FILE).to be_an_existing_file
   end
 
   def assert_cycle_sequence *args
     expected_string = args.join CYCLE_SEQUENCE_SEPARATOR
-    check_file_content(CYCLE_LOG_FILE, expected_string, true)
+    expect(CYCLE_LOG_FILE).to have_file_content(Regexp.new expected_string)
   end
 
   def assert_cycle_sequence_excluding *args
     args.each do |unexpected_string|
-      check_file_content(CYCLE_LOG_FILE, unexpected_string, false)
+      expect(CYCLE_LOG_FILE).not_to have_file_content(unexpected_string)
     end
   end
 
   def assert_complete_cycle_sequence *args
     expected_string = "#{CYCLE_SEQUENCE_SEPARATOR}#{args.join(CYCLE_SEQUENCE_SEPARATOR)}"
-    check_exact_file_content(CYCLE_LOG_FILE, expected_string)
+    expect(CYCLE_LOG_FILE).to have_file_content(expected_string)
   end
 
   def assert_data_table_equals_json(json)
-    prep_for_fs_check do
-      log_file_contents = IO.read(DATA_TABLE_LOG_FILE)
-      actual_array      = JSON.parse(log_file_contents)
-      expected_array    = JSON.parse(json)
-      actual_array.should == expected_array
-    end
+    log_file_contents = IO.read(DATA_TABLE_LOG_FILE)
+    actual_array      = JSON.parse(log_file_contents)
+    expected_array    = JSON.parse(json)
+    expect(actual_array).to be == expected_array
   end
 
   def run_feature
@@ -302,11 +300,11 @@ EOF
   def compile_step_definitions
     remove_step_definition_obj
     compiler_output = %x[ #{COMPILE_STEP_DEFINITIONS_CMD} ]
-    expect($?.success?).to be_true, "Compilation failed!\n#{compiler_output}"
+    expect($?.success?).to be == true, "Compilation failed!\n#{compiler_output}"
   end
 
   def remove_step_definition_obj
-    remove_file STEP_DEFINITIONS_OBJ
+    remove STEP_DEFINITIONS_OBJ
   rescue Errno::ENOENT
   end
 


### PR DESCRIPTION
Same versions as #93:
- Cucumber 2.0.0
- Aruba 0.8.0
- RSpec 3.4.0

Just followed directions from Aruba deprecation messages, goes with cucumber/cucumber-tck@11d6379b9096f6aa9920e2861bd0530ca7c6302b.