### PR TITLE
Disable Nagle on TCP socket: too slow for interactive

### DIFF
--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -13,6 +13,7 @@ void SocketServer::listen(const port_type port) {
     tcp::endpoint endpoint(tcp::v4(), port);
     acceptor.open(endpoint.protocol());
     acceptor.set_option(tcp::acceptor::reuse_address(true));
+    acceptor.set_option(tcp::no_delay(true));
     acceptor.bind(endpoint);
     acceptor.listen(1);
 }


### PR DESCRIPTION
The wire-protocol is latency-bound, not bandwidth-constrained. So disable the Nagle algorithm to prevent large delays from hurting our performance too much.

This about divides my runtime in half.

NOTE: Considering that we are implementing a request-reply protocol it might be possible to improve performance without disabling the Nagle algorithm. E.g. by taking control over buffering ourselves instead of leaving it up to the iostream class.