### PR TITLE
Optionally listen on a UNIX socket instead of TCP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libboost-system-dev
       - libboost-regex-dev
       - libboost-date-time-dev 
+      - libboost-filesystem-dev
       - libboost-program-options-dev
       - libboost-test-dev
       - google-mock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     set(BOOST_MIN_VERSION "1.40")
 endif()
 
-set(CUKE_CORE_BOOST_LIBS thread system regex date_time program_options)
+set(CUKE_CORE_BOOST_LIBS thread system regex date_time program_options filesystem)
 if(NOT CUKE_DISABLE_BOOST_TEST)
     set(CUKE_TEST_BOOST_LIBS unit_test_framework)
 endif()
@@ -72,7 +72,7 @@ endif()
 
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
-    set(CUKE_EXTRA_LIBRARIES ${CUKE_EXTRA_LIBRARIES} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+    set(CUKE_EXTRA_LIBRARIES ${CUKE_EXTRA_LIBRARIES} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
 endif()
 
 #

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -1,39 +1,106 @@
 #include <cucumber-cpp/internal/connectors/wire/WireServer.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/ref.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/get.hpp>
 
 namespace cucumber {
 namespace internal {
 
+using namespace boost::asio::ip;
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+using namespace boost::asio::local;
+#endif
+
 SocketServer::SocketServer(const ProtocolHandler *protocolHandler) :
     protocolHandler(protocolHandler),
-    ios(),
-    acceptor(ios) {
+    ios() {
+}
+
+SocketServer::~SocketServer()
+{
+    removeUnixSocket();
 }
 
 void SocketServer::listen(const port_type port) {
-    tcp::endpoint endpoint(tcp::v4(), port);
-    acceptor.open(endpoint.protocol());
-    acceptor.set_option(tcp::acceptor::reuse_address(true));
-    acceptor.set_option(tcp::no_delay(true));
-    acceptor.bind(endpoint);
-    acceptor.listen(1);
+    removeUnixSocket();
+
+    boost::shared_ptr<tcp::acceptor> acceptor(
+            boost::make_shared<tcp::acceptor>(boost::ref(ios), tcp::endpoint(tcp::v4(), port)));
+    acceptor->set_option(tcp::no_delay(true));
+    acceptor->listen(1);
+    this->acceptor = acceptor;
 }
 
 SocketServer::port_type SocketServer::listenPort() const {
-  const tcp::endpoint ep(acceptor.local_endpoint());
-  return ep.port();
+    const boost::shared_ptr<tcp::acceptor>* const acceptorPtr
+        = boost::get< const boost::shared_ptr<tcp::acceptor> >(&this->acceptor);
+    if (!acceptorPtr || !*acceptorPtr)
+    {
+        // Force an exception to get thrown if we're not listening on a TCP port.
+        // Will be something like "bad file descriptor" on *nix
+        io_service local_ios;
+        return tcp::acceptor(local_ios).local_endpoint().port();
+    }
+
+    return (*acceptorPtr)->local_endpoint().port();
+}
+
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+void SocketServer::listen(const std::string& unixPath) {
+    removeUnixSocket();
+
+    if (boost::filesystem::status(unixPath).type() == boost::filesystem::socket_file)
+        boost::filesystem::remove(unixPath);
+
+    boost::shared_ptr<stream_protocol::acceptor> acceptor(
+            boost::make_shared<stream_protocol::acceptor>(boost::ref(ios), stream_protocol::endpoint(unixPath)));
+    socketToRemove = unixPath;
+    acceptor->listen(1);
+    this->acceptor = acceptor;
+}
+#endif
+
+void SocketServer::removeUnixSocket() {
+    if (!socketToRemove.empty())
+        boost::filesystem::remove(socketToRemove);
+    socketToRemove.clear();
+}
+
+namespace {
+    void processStream(std::iostream &stream, const ProtocolHandler *protocolHandler) {
+        std::string request;
+        while (getline(stream, request)) {
+            stream << protocolHandler->handle(request) << std::endl << std::flush;
+        }
+    }
+
+    class AcceptOnce
+    {
+    public:
+        typedef void result_type;
+
+        AcceptOnce(const ProtocolHandler *protocolHandler) :
+            protocolHandler(protocolHandler) {
+        }
+
+        void operator()(const boost::blank&) const {}
+
+        template <typename Protocol, typename Service>
+        void operator()(const boost::shared_ptr<basic_socket_acceptor<Protocol, Service> >& acceptor) const {
+            typename Protocol::iostream stream;
+            acceptor->accept(*stream.rdbuf());
+            processStream(stream, protocolHandler);
+        }
+
+    private:
+        const ProtocolHandler *protocolHandler;
+    };
 }
 
 void SocketServer::acceptOnce() {
-    tcp::iostream stream;
-    acceptor.accept(*stream.rdbuf());
-    processStream(stream);
-}
-
-void SocketServer::processStream(tcp::iostream &stream) {
-    std::string request;
-    while (getline(stream, request)) {
-        stream << protocolHandler->handle(request) << std::endl << std::flush;
-    }
+    boost::apply_visitor(AcceptOnce(protocolHandler), acceptor);
 }
 
 }

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -178,4 +178,18 @@ TEST_F(UnixSocketServerTest, clientCanConnect) {
     // then
     EXPECT_THAT(client, IsConnected());
 }
+
+TEST_F(UnixSocketServerTest, socketIsRemovedByDestructor) {
+    // given
+    stream_protocol::endpoint socketName = server->listenEndpoint();
+    ASSERT_TRUE(fs::exists(socketName.path()));
+
+    // when
+    stream_protocol::iostream client(server->listenEndpoint());
+    client.close();
+    TearDown();
+
+    // then
+    EXPECT_FALSE(fs::exists(socketName.path()));
+}
 #endif


### PR DESCRIPTION
When you now pass --unix $SOCK_NAME it'll bind to that path as a Unix
socket permitting Cucumber to use that as a connection point. For that
the 'unix: ' option needs to be put in the cucumber.wire file.

PS it could be implemented without the shared pointers on C++11 by taking advantage of move support. But I suspect the aim is to support C++98 given the minimal boost versions required by the CMakeLists.txt.
