### PR TITLE
Add support for using ephemeral ports

### DIFF
--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -34,6 +34,14 @@ public:
     void listen(const port_type port);
 
     /**
+     * Port number that this server is currently listening on.
+     *
+     * @throw boost::system::system_error when not listening on any TCP port or
+     *        the port cannot be determined.
+     */
+    port_type listenPort() const;
+
+    /**
      * Accept one connection
      */
     void acceptOnce();

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -18,6 +18,11 @@ void SocketServer::listen(const port_type port) {
     acceptor.listen(1);
 }
 
+SocketServer::port_type SocketServer::listenPort() const {
+  const tcp::endpoint ep(acceptor.local_endpoint());
+  return ep.port();
+}
+
 void SocketServer::acceptOnce() {
     tcp::iostream stream;
     acceptor.accept(*stream.rdbuf());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@ void acceptWireProtocol(int port, bool verbose) {
     SocketServer server(&protocolHandler);
     server.listen(port);
     if (verbose)
-        std::clog << "Listening on port " << port << std::endl;
+        std::clog << "Listening on port " << server.listenPort() << std::endl;
     server.acceptOnce();
 }
 
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     optionDescription.add_options()
         ("help,h", "help for cucumber-cpp")
         ("verbose,v", "verbose output")
-        ("port,p", value<int>(), "listening port of wireserver")
+        ("port,p", value<int>(), "listening port of wireserver, use '0' (zero) to select an ephemeral port")
         ;
     boost::program_options::variables_map optionVariableMap;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, optionDescription), optionVariableMap);

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -54,14 +54,13 @@ public:
 class SocketServerTest : public Test {
 
 protected:
-    static const unsigned short PORT = 54321;
     StrictMock<MockProtocolHandler> protocolHandler;
     SocketServer *server;
     thread *serverThread;
 
     virtual void SetUp() {
         server = new SocketServer(&protocolHandler);
-        server->listen(PORT);
+        server->listen(0);
         serverThread = new thread(bind(&SocketServer::acceptOnce, server));
     }
 
@@ -79,7 +78,7 @@ protected:
 
 TEST_F(SocketServerTest, exitsOnFirstConnectionClosed) {
     // given
-    tcp::iostream client(tcp::endpoint(tcp::v4(), PORT));
+    tcp::iostream client(tcp::endpoint(tcp::v4(), server->listenPort()));
     ASSERT_THAT(client, IsConnected());
 
     // when
@@ -91,11 +90,11 @@ TEST_F(SocketServerTest, exitsOnFirstConnectionClosed) {
 
 TEST_F(SocketServerTest, moreThanOneClientCanConnect) {
     // given
-    tcp::iostream client1(tcp::endpoint(tcp::v4(), PORT));
+    tcp::iostream client1(tcp::endpoint(tcp::v4(), server->listenPort()));
     ASSERT_THAT(client1, IsConnected());
 
     // when
-    tcp::iostream client2(tcp::endpoint(tcp::v4(), PORT));
+    tcp::iostream client2(tcp::endpoint(tcp::v4(), server->listenPort()));
 
     //then
     ASSERT_THAT(client2, IsConnected());
@@ -110,7 +109,7 @@ TEST_F(SocketServerTest, receiveAndSendsSingleLineMassages) {
     }
 
     // given
-    tcp::iostream client(tcp::endpoint(tcp::v4(), PORT));
+    tcp::iostream client(tcp::endpoint(tcp::v4(), server->listenPort()));
     ASSERT_THAT(client, IsConnected());
 
     // when

--- a/travis.sh
+++ b/travis.sh
@@ -18,8 +18,10 @@ BOOST=build/examples/Calc/BoostCalculatorSteps
 if [ -f $GTEST ]; then
     $GTEST >/dev/null &
     cucumber examples/Calc
+    wait
 fi
 if [ -f $BOOST ]; then
     $BOOST >/dev/null &
     cucumber examples/Calc
+    wait
 fi


### PR DESCRIPTION
Ephemeral ports are used when binding to port '0'. The operating system
then automatically selects a (non-zero) port for you that's unused at
the time. This is great to prevent conflicts.

This commit extends the wire server such that it reports the actual port
number we've bound to, even when using ephemeral ports. This is useful
to prevent port conflicts on CI systems running many tests in parallel.