### PR TITLE
Throw by value, catch by reference

### DIFF
--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -50,9 +50,9 @@ WireResponse *InvokeCommand::run(CukeEngine *engine) const {
     try {
         engine->invokeStep(stepId, *args, *tableArg);
         return new SuccessResponse;
-    } catch (InvokeFailureException e) {
+    } catch (const InvokeFailureException& e) {
         return new FailureResponse(e.getMessage(), e.getExceptionType());
-    } catch (PendingStepException e) {
+    } catch (const PendingStepException& e) {
         return new PendingResponse(e.getMessage());
     } catch (...) {
         return new FailureResponse;


### PR DESCRIPTION
To prevent object-splicing at the catch site.