### PR TITLE
Travis: output CTest error log on failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ build_script:
 - cmd: cmake --build build
 
 test_script:
+- cmd: set CTEST_OUTPUT_ON_FAILURE=ON
 - cmd: cmake --build build --target test
 - cmd: cmake --build build --target features
 

--- a/travis.sh
+++ b/travis.sh
@@ -3,6 +3,9 @@ set -e #break script on non-zero exitcode from any command
 gem install bundler
 bundle install
 
+CTEST_OUTPUT_ON_FAILURE=ON
+export CTEST_OUTPUT_ON_FAILURE
+
 cmake -E make_directory build
 if [ -z ${GMOCK_PATH+x} ]; then
     cmake -E chdir build cmake -DCUKE_ENABLE_EXAMPLES=on -DGMOCK_VER=${GMOCK_VER} ..


### PR DESCRIPTION
This causes CTest to output the stdout/stderr log of failing test cases when encountered.