### PR TITLE
Test with Valgrind, stop leaking, more memory safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env: GMOCK_PATH=/usr/src/gmock
     - os: osx
       compiler: gcc #does anyone on osx use it?
+  include:
+    - os: linux
+      compiler: gcc
+      env: GMOCK_VER=1.8.0 VALGRIND_TESTS=ON
 
 addons:
   apt:
@@ -30,6 +34,7 @@ addons:
       - libboost-test-dev
       - google-mock
       - ninja-build
+      - valgrind
 
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then brew update && brew install ninja; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CUKE_DISABLE_E2E_TESTS OFF CACHE BOOL "Disable end-to-end tests")
 set(CUKE_ENABLE_EXAMPLES OFF CACHE BOOL "Enable the examples")
 set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise downloaded)")
 set(GMOCK_VER "1.7.0" CACHE STRING "Google Mock framework version to be used")
+option(VALGRIND_TESTS "Run tests within Valgrind" OFF)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
@@ -100,6 +101,52 @@ if(NOT CUKE_DISABLE_GTEST)
             GMock::Main
             )
     endif()
+endif()
+
+#
+# Valgrind
+#
+
+if(VALGRIND_TESTS)
+    find_program(VALGRIND_CMD valgrind)
+    if(NOT VALGRIND_CMD)
+        message(SEND_ERROR "Failed to find 'valgrind', cannot run tests with it as requested")
+    endif()
+    set(VALGRIND_ARGS --error-exitcode=2 --leak-check=full --show-leak-kinds=all --undef-value-errors=no)
+    function(add_test name)
+        if(NOT name STREQUAL "NAME")
+            _add_test(${VALGRIND_CMD} ${VALGRIND_ARGS} ${ARGV})
+            return()
+        endif()
+
+        set(TEST_ARGS ${ARGV})
+        list(FIND TEST_ARGS COMMAND COMMAND_IDX)
+        if(COMMAND_IDX EQUAL -1)
+            message(AUTHOR_WARNING "Weird command-line given to add_test(), not injecting valgrind")
+            _add_test(${ARGV})
+            return()
+        endif()
+
+        # We want to operate on the COMMAND, not the 'COMMAND' keyword preceding it
+        math(EXPR COMMAND_IDX "${COMMAND_IDX} + 1")
+
+        # Keep add_test() behaviour of replacing COMMANDs, when executable targets, with their output files
+        list(GET TEST_ARGS ${COMMAND_IDX} COMMAND)
+        if(TARGET ${COMMAND})
+            get_target_property(COMMAND_TYPE ${COMMAND} TYPE)
+            if(COMMAND_TYPE STREQUAL "EXECUTABLE")
+                # Inserting first, removing the original only after that, because inserting to the end of the list doesn't work
+                math(EXPR ORIG_COMMAND_IDX "${COMMAND_IDX} + 1")
+                list(INSERT TEST_ARGS ${COMMAND_IDX} "$<TARGET_FILE:${COMMAND}>")
+                list(REMOVE_AT TEST_ARGS ${ORIG_COMMAND_IDX})
+            endif()
+        endif()
+
+        # Insert the valgrind command line, before the command to execute
+        list(INSERT TEST_ARGS ${COMMAND_IDX} ${VALGRIND_CMD} ${VALGRIND_ARGS})
+
+        _add_test(${TEST_ARGS})
+    endfunction()
 endif()
 
 #

--- a/include/cucumber-cpp/internal/ContextManager.hpp
+++ b/include/cucumber-cpp/internal/ContextManager.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 
@@ -26,7 +27,7 @@ protected:
 
 template<class T>
 weak_ptr<T> ContextManager::addContext() {
-    shared_ptr<T> shared(new T);
+    shared_ptr<T> shared(boost::make_shared<T>());
     contexts.push_back(shared);
     return weak_ptr<T> (shared);
 }

--- a/include/cucumber-cpp/internal/CukeCommands.hpp
+++ b/include/cucumber-cpp/internal/CukeCommands.hpp
@@ -26,7 +26,7 @@ public:
 	CukeCommands();
 	virtual ~CukeCommands();
 
-    void beginScenario(const TagExpression::tag_list *tags);
+    void beginScenario(const TagExpression::tag_list& tags = TagExpression::tag_list());
     void endScenario();
     const std::string snippetText(const std::string stepKeyword, const std::string stepName) const;
     MatchResult stepMatches(const std::string description) const;

--- a/include/cucumber-cpp/internal/Scenario.hpp
+++ b/include/cucumber-cpp/internal/Scenario.hpp
@@ -8,11 +8,11 @@ namespace internal {
 
 class Scenario {
 public:
-    Scenario(const TagExpression::tag_list *pTags);
+    Scenario(const TagExpression::tag_list& tags = TagExpression::tag_list());
 
     const TagExpression::tag_list & getTags();
 private:
-    shared_ptr<const TagExpression::tag_list> pTags;
+    const TagExpression::tag_list tags;
 };
 
 }

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -3,6 +3,7 @@
 
 #include "ProtocolHandler.hpp"
 #include "../../CukeEngine.hpp"
+#include <boost/shared_ptr.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -17,14 +18,14 @@ class WireResponse {
 public:
     WireResponse() {};
 
-    virtual void accept(WireResponseVisitor *visitor) const = 0;
+    virtual void accept(WireResponseVisitor& visitor) const = 0;
 
     virtual ~WireResponse() {};
 };
 
 class SuccessResponse : public WireResponse {
 public:
-    void accept(WireResponseVisitor *visitor) const;
+    void accept(WireResponseVisitor& visitor) const;
 };
 
 class FailureResponse : public WireResponse {
@@ -37,7 +38,7 @@ public:
     const std::string getMessage() const;
     const std::string getExceptionType() const;
 
-    void accept(WireResponseVisitor *visitor) const;
+    void accept(WireResponseVisitor& visitor) const;
 };
 
 class PendingResponse : public WireResponse {
@@ -49,7 +50,7 @@ public:
 
     const std::string getMessage() const;
 
-    void accept(WireResponseVisitor *visitor) const;
+    void accept(WireResponseVisitor& visitor) const;
 };
 
 class StepMatchesResponse : public WireResponse {
@@ -60,7 +61,7 @@ public:
     StepMatchesResponse(const std::vector<StepMatch> & matchingSteps);
     const std::vector<StepMatch>& getMatchingSteps() const;
 
-    void accept(WireResponseVisitor *visitor) const;
+    void accept(WireResponseVisitor& visitor) const;
 };
 
 class SnippetTextResponse : public WireResponse {
@@ -72,16 +73,16 @@ public:
 
     const std::string getStepSnippet() const;
 
-    void accept(WireResponseVisitor *visitor) const;
+    void accept(WireResponseVisitor& visitor) const;
 };
 
 class WireResponseVisitor {
 public:
-    virtual void visit(const SuccessResponse *response) = 0;
-    virtual void visit(const FailureResponse *response) = 0;
-    virtual void visit(const PendingResponse *response) = 0;
-    virtual void visit(const StepMatchesResponse *response) = 0;
-    virtual void visit(const SnippetTextResponse *response) = 0;
+    virtual void visit(const SuccessResponse& response) = 0;
+    virtual void visit(const FailureResponse& response) = 0;
+    virtual void visit(const PendingResponse& response) = 0;
+    virtual void visit(const StepMatchesResponse& response) = 0;
+    virtual void visit(const SnippetTextResponse& response) = 0;
 
     virtual ~WireResponseVisitor() {};
 };
@@ -99,7 +100,7 @@ public:
      *
      * @return The command response (ownership passed to the caller)
      */
-    virtual WireResponse *run(CukeEngine *engine) const = 0;
+    virtual boost::shared_ptr<WireResponse> run(CukeEngine& engine) const = 0;
 
     virtual ~WireCommand() {};
 };
@@ -133,7 +134,7 @@ public:
      *
      * @throws WireMessageCodecException
      */
-    virtual WireCommand *decode(const std::string &request) const = 0;
+    virtual boost::shared_ptr<WireCommand> decode(const std::string &request) const = 0;
 
     /**
      * Encodes a response to wire format.
@@ -142,7 +143,7 @@ public:
      *
      * @return The encoded string
      */
-    virtual const std::string encode(const WireResponse *response) const = 0;
+    virtual const std::string encode(const WireResponse& response) const = 0;
 
     virtual ~WireMessageCodec() {};
 };
@@ -153,8 +154,8 @@ public:
 class JsonSpiritWireMessageCodec : public WireMessageCodec {
 public:
     JsonSpiritWireMessageCodec();
-    WireCommand *decode(const std::string &request) const;
-    const std::string encode(const WireResponse *response) const;
+    boost::shared_ptr<WireCommand> decode(const std::string &request) const;
+    const std::string encode(const WireResponse& response) const;
 };
 
 /**
@@ -163,11 +164,11 @@ public:
  */
 class WireProtocolHandler : public ProtocolHandler {
 private:
-    const WireMessageCodec *codec;
-    CukeEngine *engine;
+    const WireMessageCodec& codec;
+    CukeEngine& engine;
 
 public:
-    WireProtocolHandler(const WireMessageCodec *codec, CukeEngine *engine);
+    WireProtocolHandler(const WireMessageCodec& codec, CukeEngine& engine);
 
     std::string handle(const std::string &request) const;
 };

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp
@@ -2,31 +2,32 @@
 #define CUKE_WIREPROTOCOL_COMMANDS_HPP_
 
 #include "WireProtocol.hpp"
+#include <boost/shared_ptr.hpp>
 
 namespace cucumber {
 namespace internal {
 
 class ScenarioCommand : public WireCommand {
 protected:
-    std::auto_ptr<const CukeEngine::tags_type> tags;
+    const CukeEngine::tags_type tags;
 
-    ScenarioCommand(const CukeEngine::tags_type *tags);
+    ScenarioCommand(const CukeEngine::tags_type& tags);
 };
 
 
 class BeginScenarioCommand : public ScenarioCommand {
 public:
-    BeginScenarioCommand(const CukeEngine::tags_type *tags);
+    BeginScenarioCommand(const CukeEngine::tags_type& tags);
 
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
 class EndScenarioCommand : public ScenarioCommand {
 public:
-    EndScenarioCommand(const CukeEngine::tags_type *tags);
+    EndScenarioCommand(const CukeEngine::tags_type& tags);
 
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -37,22 +38,22 @@ private:
 public:
     StepMatchesCommand(const std::string & stepName);
 
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
 class InvokeCommand : public WireCommand {
 private:
     const std::string stepId;
-    std::auto_ptr<const CukeEngine::invoke_args_type> args;
-    std::auto_ptr<const CukeEngine::invoke_table_type> tableArg;
+    const CukeEngine::invoke_args_type args;
+    const CukeEngine::invoke_table_type tableArg;
 
 public:
     InvokeCommand(const std::string & stepId,
-                  const CukeEngine::invoke_args_type *args,
-                  const CukeEngine::invoke_table_type * tableArg);
+                  const CukeEngine::invoke_args_type& args,
+                  const CukeEngine::invoke_table_type& tableArg);
 
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -65,13 +66,13 @@ public:
                        const std::string & name,
                        const std::string & multilineArgClass);
 
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
 class FailingCommand : public WireCommand {
 public:
-    WireResponse *run(CukeEngine *engine) const;
+    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 }

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -5,6 +5,7 @@
 #include "../Scenario.hpp"
 #include "../step/StepManager.hpp"
 
+#include <boost/make_shared.hpp>
 #include <boost/smart_ptr.hpp>
 using boost::shared_ptr;
 
@@ -60,27 +61,27 @@ class AfterAllHook : public UnconditionalHook {
 
 class HookRegistrar {
 public:
-    typedef std::list<Hook *> hook_list_type;
-    typedef std::list<AroundStepHook *> aroundhook_list_type;
+    typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
+    typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
 
     virtual ~HookRegistrar();
 
-    void addBeforeHook(BeforeHook *afterHook);
+    void addBeforeHook(const boost::shared_ptr<BeforeHook>& afterHook);
     void execBeforeHooks(Scenario *scenario);
 
-    void addAroundStepHook(AroundStepHook *aroundStepHook);
-    InvokeResult execStepChain(Scenario *scenario, StepInfo *stepInfo, const InvokeArgs *pArgs);
+    void addAroundStepHook(const boost::shared_ptr<AroundStepHook>& aroundStepHook);
+    InvokeResult execStepChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pArgs);
 
-    void addAfterStepHook(AfterStepHook *afterStepHook);
+    void addAfterStepHook(const boost::shared_ptr<AfterStepHook>& afterStepHook);
     void execAfterStepHooks(Scenario *scenario);
 
-    void addAfterHook(AfterHook *afterHook);
+    void addAfterHook(const boost::shared_ptr<AfterHook>& afterHook);
     void execAfterHooks(Scenario *scenario);
 
-    void addBeforeAllHook(BeforeAllHook *beforeAllHook);
+    void addBeforeAllHook(const boost::shared_ptr<BeforeAllHook>& beforeAllHook);
     void execBeforeAllHooks();
 
-    void addAfterAllHook(AfterAllHook *afterAllHook);
+    void addAfterAllHook(const boost::shared_ptr<AfterAllHook>& afterAllHook);
     void execAfterAllHooks();
 
 private:
@@ -98,14 +99,14 @@ protected:
 
 class StepCallChain {
 public:
-    StepCallChain(Scenario *scenario, StepInfo *stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
+    StepCallChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
     InvokeResult exec();
     void execNext();
 private:
     void execStep();
 
     Scenario *scenario;
-    StepInfo *stepInfo;
+    boost::shared_ptr<StepInfo> stepInfo;
     const InvokeArgs *pStepArgs;
 
     HookRegistrar::aroundhook_list_type::iterator nextHook;
@@ -125,7 +126,7 @@ private:
 template<class T>
 static int registerBeforeHook(const std::string &csvTagNotation) {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    hook->setTags(csvTagNotation);
    reg.addBeforeHook(hook);
    return 0; // We are not interested in the ID at this time
@@ -134,7 +135,7 @@ static int registerBeforeHook(const std::string &csvTagNotation) {
 template<class T>
 static int registerAroundStepHook(const std::string &csvTagNotation) {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    hook->setTags(csvTagNotation);
    reg.addAroundStepHook(hook);
    return 0;
@@ -143,7 +144,7 @@ static int registerAroundStepHook(const std::string &csvTagNotation) {
 template<class T>
 static int registerAfterStepHook(const std::string &csvTagNotation) {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    hook->setTags(csvTagNotation);
    reg.addAfterStepHook(hook);
    return 0;
@@ -152,7 +153,7 @@ static int registerAfterStepHook(const std::string &csvTagNotation) {
 template<class T>
 static int registerAfterHook(const std::string &csvTagNotation) {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    hook->setTags(csvTagNotation);
    reg.addAfterHook(hook);
    return 0;
@@ -161,7 +162,7 @@ static int registerAfterHook(const std::string &csvTagNotation) {
 template<class T>
 static int registerBeforeAllHook() {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    reg.addBeforeAllHook(hook);
    return 0;
 }
@@ -169,7 +170,7 @@ static int registerBeforeAllHook() {
 template<class T>
 static int registerAfterAllHook() {
    HookRegistrar reg;
-   T *hook = new T;
+   boost::shared_ptr<T> hook(boost::make_shared<T>());
    reg.addAfterAllHook(hook);
    return 0;
 }

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -70,7 +70,7 @@ public:
     void execBeforeHooks(Scenario *scenario);
 
     void addAroundStepHook(const boost::shared_ptr<AroundStepHook>& aroundStepHook);
-    InvokeResult execStepChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pArgs);
+    InvokeResult execStepChain(Scenario *scenario, const boost::shared_ptr<const StepInfo>& stepInfo, const InvokeArgs *pArgs);
 
     void addAfterStepHook(const boost::shared_ptr<AfterStepHook>& afterStepHook);
     void execAfterStepHooks(Scenario *scenario);
@@ -99,14 +99,14 @@ protected:
 
 class StepCallChain {
 public:
-    StepCallChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
+    StepCallChain(Scenario *scenario, const boost::shared_ptr<const StepInfo>& stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
     InvokeResult exec();
     void execNext();
 private:
     void execStep();
 
     Scenario *scenario;
-    boost::shared_ptr<StepInfo> stepInfo;
+    boost::shared_ptr<const StepInfo> stepInfo;
     const InvokeArgs *pStepArgs;
 
     HookRegistrar::aroundhook_list_type::iterator nextHook;

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -100,8 +100,8 @@ public:
 class StepInfo {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
-    SingleStepMatch matches(const std::string &stepDescription);
-    virtual InvokeResult invokeStep(const InvokeArgs * pArgs) = 0;
+    SingleStepMatch matches(const std::string &stepDescription) const;
+    virtual InvokeResult invokeStep(const InvokeArgs * pArgs) const = 0;
 
     step_id_type id;
     Regex regex;
@@ -142,20 +142,20 @@ class StepInvoker : public StepInfo {
 public:
     StepInvoker(const std::string &stepMatcher, const std::string source);
 
-    InvokeResult invokeStep(const InvokeArgs *args);
+    InvokeResult invokeStep(const InvokeArgs *args) const;
 };
 
 
 class StepManager {
 protected:
-    typedef std::map<step_id_type, boost::shared_ptr<StepInfo> > steps_type;
+    typedef std::map<step_id_type, boost::shared_ptr<const StepInfo> > steps_type;
 
 public:
     virtual ~StepManager();
 
     void addStep(const boost::shared_ptr<StepInfo>& stepInfo);
     MatchResult stepMatches(const std::string &stepDescription) const;
-    const boost::shared_ptr<StepInfo>& getStep(step_id_type id);
+    const boost::shared_ptr<const StepInfo>& getStep(step_id_type id);
 protected:
     steps_type& steps() const;
 };
@@ -228,7 +228,7 @@ StepInvoker<T>::StepInvoker(const std::string &stepMatcher, const std::string so
 }
 
 template<class T>
-InvokeResult StepInvoker<T>::invokeStep(const InvokeArgs *pArgs) {
+InvokeResult StepInvoker<T>::invokeStep(const InvokeArgs *pArgs) const {
     T t;
     return t.invoke(pArgs);
 }

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 using boost::shared_ptr;
 
@@ -147,14 +148,14 @@ public:
 
 class StepManager {
 protected:
-    typedef std::map<step_id_type, StepInfo *> steps_type;
+    typedef std::map<step_id_type, boost::shared_ptr<StepInfo> > steps_type;
 
 public:
     virtual ~StepManager();
 
-    void addStep(StepInfo *stepInfo);
+    void addStep(const boost::shared_ptr<StepInfo>& stepInfo);
     MatchResult stepMatches(const std::string &stepDescription) const;
-    StepInfo *getStep(step_id_type id);
+    const boost::shared_ptr<StepInfo>& getStep(step_id_type id);
 protected:
     steps_type& steps() const;
 };
@@ -177,7 +178,7 @@ static inline std::string toSourceString(const char *filePath, const int line) {
 template<class T>
 static int registerStep(const std::string &stepMatcher, const char *file, const int line) {
    StepManager s;
-   StepInfo *stepInfo = new StepInvoker<T>(stepMatcher, toSourceString(file, line));
+   boost::shared_ptr<StepInfo> stepInfo(boost::make_shared< StepInvoker<T> >(stepMatcher, toSourceString(file, line)));
    s.addStep(stepInfo);
    return stepInfo->id;
 }

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/enable_shared_from_this.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 using boost::shared_ptr;
@@ -25,13 +26,9 @@ class SingleStepMatch {
 public:
     typedef RegexMatch::submatches_type submatches_type;
 
-    SingleStepMatch();
-    SingleStepMatch(const SingleStepMatch &match);
-
-    SingleStepMatch & operator =(const SingleStepMatch &match);
     operator const void *() const;
 
-    const StepInfo *stepInfo;
+    boost::shared_ptr<const StepInfo> stepInfo;
     submatches_type submatches;
 };
 
@@ -97,7 +94,7 @@ public:
 };
 
 
-class StepInfo {
+class StepInfo : public boost::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
     SingleStepMatch matches(const std::string &stepDescription) const;

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -29,7 +29,7 @@ public:
     SingleStepMatch(const SingleStepMatch &match);
 
     SingleStepMatch & operator =(const SingleStepMatch &match);
-    operator void *();
+    operator const void *() const;
 
     const StepInfo *stepInfo;
     submatches_type submatches;

--- a/include/cucumber-cpp/internal/utils/Regex.hpp
+++ b/include/cucumber-cpp/internal/utils/Regex.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
 
 namespace cucumber {
@@ -46,8 +47,8 @@ private:
 public:
     Regex(std::string expr);
 
-    RegexMatch *find(const std::string &expression);
-    RegexMatch *findAll(const std::string &expression);
+    boost::shared_ptr<RegexMatch> find(const std::string &expression) const;
+    boost::shared_ptr<RegexMatch> findAll(const std::string &expression) const;
 
     std::string str() const;
 };

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -18,7 +18,7 @@ CukeCommands::~CukeCommands() {
     }
 }
 
-void CukeCommands::beginScenario(const TagExpression::tag_list *tags) {
+void CukeCommands::beginScenario(const TagExpression::tag_list& tags) {
     if (!hasStarted) {
         hasStarted = true;
         hookRegistrar.execBeforeAllHooks();
@@ -58,7 +58,7 @@ MatchResult CukeCommands::stepMatches(const std::string description) const {
 }
 
 InvokeResult CukeCommands::invoke(step_id_type id, const InvokeArgs *pArgs) {
-    StepInfo *stepInfo = stepManager.getStep(id);
+    boost::shared_ptr<StepInfo> stepInfo = stepManager.getStep(id);
     InvokeResult result = hookRegistrar.execStepChain(currentScenario.get(), stepInfo, pArgs);
     hookRegistrar.execAfterStepHooks(currentScenario.get());
     return result;

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -58,7 +58,7 @@ MatchResult CukeCommands::stepMatches(const std::string description) const {
 }
 
 InvokeResult CukeCommands::invoke(step_id_type id, const InvokeArgs *pArgs) {
-    boost::shared_ptr<StepInfo> stepInfo = stepManager.getStep(id);
+    boost::shared_ptr<const StepInfo> stepInfo = stepManager.getStep(id);
     InvokeResult result = hookRegistrar.execStepChain(currentScenario.get(), stepInfo, pArgs);
     hookRegistrar.execAfterStepHooks(currentScenario.get());
     return result;

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <boost/algorithm/string.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -23,7 +24,7 @@ void CukeCommands::beginScenario(const TagExpression::tag_list *tags) {
         hookRegistrar.execBeforeAllHooks();
     }
 
-    currentScenario = shared_ptr<Scenario>(new Scenario(tags));
+    currentScenario = boost::make_shared<Scenario>(tags);
     hookRegistrar.execBeforeHooks(currentScenario.get());
 }
 

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -41,7 +41,7 @@ std::vector<StepMatch> CukeEngineImpl::stepMatches(const std::string & name) con
 }
 
 void CukeEngineImpl::beginScenario(const tags_type & tags) {
-    cukeCommands.beginScenario(&tags);
+    cukeCommands.beginScenario(tags);
 }
 
 void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type & args, const invoke_table_type & tableArg) {

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -40,7 +40,7 @@ void UnconditionalHook::invokeHook(Scenario*, CallableStep *) {
 HookRegistrar::~HookRegistrar() {
 }
 
-void HookRegistrar::addBeforeHook(BeforeHook *beforeHook) {
+void HookRegistrar::addBeforeHook(const boost::shared_ptr<BeforeHook>& beforeHook) {
     beforeHooks().push_back(beforeHook);
 }
 
@@ -54,7 +54,7 @@ void HookRegistrar::execBeforeHooks(Scenario *scenario) {
 }
 
 
-void HookRegistrar::addAroundStepHook(AroundStepHook *aroundStepHook) {
+void HookRegistrar::addAroundStepHook(const boost::shared_ptr<AroundStepHook>& aroundStepHook) {
     aroundStepHooks().push_front(aroundStepHook);
 }
 
@@ -63,12 +63,12 @@ HookRegistrar::aroundhook_list_type& HookRegistrar::aroundStepHooks() {
     return aroundStepHooks;
 }
 
-InvokeResult HookRegistrar::execStepChain(Scenario *scenario, StepInfo *stepInfo, const InvokeArgs *pArgs) {
+InvokeResult HookRegistrar::execStepChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pArgs) {
     StepCallChain scc(scenario, stepInfo, pArgs, aroundStepHooks());
     return scc.exec();
 }
 
-void HookRegistrar::addAfterStepHook(AfterStepHook *afterStepHook) {
+void HookRegistrar::addAfterStepHook(const boost::shared_ptr<AfterStepHook>& afterStepHook) {
     afterStepHooks().push_front(afterStepHook);
 }
 
@@ -82,7 +82,7 @@ void HookRegistrar::execAfterStepHooks(Scenario *scenario) {
 }
 
 
-void HookRegistrar::addAfterHook(AfterHook *afterHook) {
+void HookRegistrar::addAfterHook(const boost::shared_ptr<AfterHook>& afterHook) {
     afterHooks().push_front(afterHook);
 }
 
@@ -107,7 +107,7 @@ HookRegistrar::hook_list_type& HookRegistrar::beforeAllHooks() {
     return beforeAllHooks;
 }
 
-void HookRegistrar::addBeforeAllHook(BeforeAllHook *beforeAllHook) {
+void HookRegistrar::addBeforeAllHook(const boost::shared_ptr<BeforeAllHook>& beforeAllHook) {
     beforeAllHooks().push_back(beforeAllHook);
 }
 
@@ -120,7 +120,7 @@ HookRegistrar::hook_list_type& HookRegistrar::afterAllHooks() {
     return afterAllHooks;
 }
 
-void HookRegistrar::addAfterAllHook(AfterAllHook *afterAllHook) {
+void HookRegistrar::addAfterAllHook(const boost::shared_ptr<AfterAllHook>& afterAllHook) {
     afterAllHooks().push_back(afterAllHook);
 }
 
@@ -131,7 +131,7 @@ void HookRegistrar::execAfterAllHooks() {
 
 StepCallChain::StepCallChain(
     Scenario *scenario,
-    StepInfo *stepInfo,
+    const boost::shared_ptr<StepInfo>& stepInfo,
     const InvokeArgs *pStepArgs,
     HookRegistrar::aroundhook_list_type &aroundHooks
 ) :

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -44,8 +44,8 @@ void HookRegistrar::addBeforeHook(BeforeHook *beforeHook) {
 }
 
 HookRegistrar::hook_list_type& HookRegistrar::beforeHooks() {
-    static hook_list_type *beforeHooks = new hook_list_type();
-    return *beforeHooks;
+    static hook_list_type beforeHooks;
+    return beforeHooks;
 }
 
 void HookRegistrar::execBeforeHooks(Scenario *scenario) {
@@ -58,8 +58,8 @@ void HookRegistrar::addAroundStepHook(AroundStepHook *aroundStepHook) {
 }
 
 HookRegistrar::aroundhook_list_type& HookRegistrar::aroundStepHooks() {
-    static aroundhook_list_type *aroundStepHooks = new aroundhook_list_type();
-    return *aroundStepHooks;
+    static aroundhook_list_type aroundStepHooks;
+    return aroundStepHooks;
 }
 
 InvokeResult HookRegistrar::execStepChain(Scenario *scenario, StepInfo *stepInfo, const InvokeArgs *pArgs) {
@@ -72,8 +72,8 @@ void HookRegistrar::addAfterStepHook(AfterStepHook *afterStepHook) {
 }
 
 HookRegistrar::hook_list_type& HookRegistrar::afterStepHooks() {
-    static hook_list_type *afterStepHooks = new hook_list_type();
-    return *afterStepHooks;
+    static hook_list_type afterStepHooks;
+    return afterStepHooks;
 }
 
 void HookRegistrar::execAfterStepHooks(Scenario *scenario) {
@@ -86,8 +86,8 @@ void HookRegistrar::addAfterHook(AfterHook *afterHook) {
 }
 
 HookRegistrar::hook_list_type& HookRegistrar::afterHooks() {
-    static hook_list_type *afterHooks = new hook_list_type();
-    return *afterHooks;
+    static hook_list_type afterHooks;
+    return afterHooks;
 }
 
 void HookRegistrar::execAfterHooks(Scenario *scenario) {
@@ -102,8 +102,8 @@ void HookRegistrar::execHooks(HookRegistrar::hook_list_type &hookList, Scenario 
 }
 
 HookRegistrar::hook_list_type& HookRegistrar::beforeAllHooks() {
-    static hook_list_type *beforeAllHooks = new hook_list_type();
-    return *beforeAllHooks;
+    static hook_list_type beforeAllHooks;
+    return beforeAllHooks;
 }
 
 void HookRegistrar::addBeforeAllHook(BeforeAllHook *beforeAllHook) {
@@ -115,8 +115,8 @@ void HookRegistrar::execBeforeAllHooks() {
 }
 
 HookRegistrar::hook_list_type& HookRegistrar::afterAllHooks() {
-    static hook_list_type *afterAllHooks = new hook_list_type();
-    return *afterAllHooks;
+    static hook_list_type afterAllHooks;
+    return afterAllHooks;
 }
 
 void HookRegistrar::addAfterAllHook(AfterAllHook *afterAllHook) {

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -63,7 +63,7 @@ HookRegistrar::aroundhook_list_type& HookRegistrar::aroundStepHooks() {
     return aroundStepHooks;
 }
 
-InvokeResult HookRegistrar::execStepChain(Scenario *scenario, const boost::shared_ptr<StepInfo>& stepInfo, const InvokeArgs *pArgs) {
+InvokeResult HookRegistrar::execStepChain(Scenario *scenario, const boost::shared_ptr<const StepInfo>& stepInfo, const InvokeArgs *pArgs) {
     StepCallChain scc(scenario, stepInfo, pArgs, aroundStepHooks());
     return scc.exec();
 }
@@ -131,7 +131,7 @@ void HookRegistrar::execAfterAllHooks() {
 
 StepCallChain::StepCallChain(
     Scenario *scenario,
-    const boost::shared_ptr<StepInfo>& stepInfo,
+    const boost::shared_ptr<const StepInfo>& stepInfo,
     const InvokeArgs *pStepArgs,
     HookRegistrar::aroundhook_list_type &aroundHooks
 ) :

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -1,5 +1,6 @@
 #include <cucumber-cpp/internal/hook/HookRegistrar.hpp>
 #include <cucumber-cpp/internal/CukeCommands.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -16,7 +17,7 @@ void Hook::skipHook() {
 }
 
 void Hook::setTags(const std::string &csvTagNotation) {
-    tagExpression = shared_ptr<TagExpression>(new AndTagExpression(csvTagNotation));
+    tagExpression = boost::make_shared<AndTagExpression>(csvTagNotation);
 }
 
 bool Hook::tagsMatch(Scenario *scenario) {

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/utils/Regex.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -19,8 +20,8 @@ std::string Regex::str() const {
     return regexImpl.str();
 }
 
-RegexMatch *Regex::find(const std::string &expression) {
-    return new FindRegexMatch(regexImpl, expression);
+boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
+    return boost::make_shared<FindRegexMatch>(regexImpl, expression);
 }
 
 FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
@@ -36,8 +37,8 @@ FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string 
     }
 }
 
-RegexMatch *Regex::findAll(const std::string &expression) {
-    return new FindAllRegexMatch(regexImpl, expression);
+boost::shared_ptr<RegexMatch> Regex::findAll(const std::string &expression) const {
+    return boost::make_shared<FindAllRegexMatch>(regexImpl, expression);
 }
 
 FindAllRegexMatch::FindAllRegexMatch(const boost::regex &regexImpl, const std::string &expression) {

--- a/src/Scenario.cpp
+++ b/src/Scenario.cpp
@@ -4,15 +4,12 @@
 namespace cucumber {
 namespace internal {
 
-Scenario::Scenario(const TagExpression::tag_list *pTags) :
-    pTags(pTags) {
-    if (!pTags) {
-        this->pTags = boost::make_shared<const TagExpression::tag_list>();
-    }
+Scenario::Scenario(const TagExpression::tag_list& tags) :
+    tags(tags) {
 };
 
 const TagExpression::tag_list & Scenario::getTags() {
-    return *(pTags.get());
+    return tags;
 }
 
 }

--- a/src/Scenario.cpp
+++ b/src/Scenario.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/Scenario.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -6,7 +7,7 @@ namespace internal {
 Scenario::Scenario(const TagExpression::tag_list *pTags) :
     pTags(pTags) {
     if (!pTags) {
-        this->pTags = shared_ptr<const TagExpression::tag_list>(new TagExpression::tag_list);
+        this->pTags = boost::make_shared<const TagExpression::tag_list>();
     }
 };
 

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -126,14 +126,14 @@ const std::string &InvokeResult::getDescription() const {
 StepManager::~StepManager() {
 }
 
-void StepManager::addStep(StepInfo *stepInfo) {
+void StepManager::addStep(const boost::shared_ptr<StepInfo>& stepInfo) {
     steps().insert(std::make_pair(stepInfo->id, stepInfo));
 }
 
 MatchResult StepManager::stepMatches(const std::string &stepDescription) const {
     MatchResult matchResult;
     for (steps_type::iterator iter = steps().begin(); iter != steps().end(); ++iter) {
-        StepInfo *stepInfo = iter->second;
+        const boost::shared_ptr<StepInfo>& stepInfo = iter->second;
         SingleStepMatch currentMatch = stepInfo->matches(stepDescription);
         if (currentMatch) {
             matchResult.addMatch(currentMatch);
@@ -142,7 +142,7 @@ MatchResult StepManager::stepMatches(const std::string &stepDescription) const {
     return matchResult;
 }
 
-StepInfo *StepManager::getStep(step_id_type id) {
+const boost::shared_ptr<StepInfo>& StepManager::getStep(step_id_type id) {
     return steps()[id];
 }
 

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -15,29 +15,14 @@ SingleStepMatch StepInfo::matches(const std::string &stepDescription) const {
     SingleStepMatch stepMatch;
     shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
     if (regexMatch->matches()) {
-        stepMatch.stepInfo = this;
+        stepMatch.stepInfo = shared_from_this();
         stepMatch.submatches = regexMatch->getSubmatches();
     }
     return stepMatch;
 }
 
-SingleStepMatch::SingleStepMatch() :
-    stepInfo(0) {
-}
-
-SingleStepMatch::SingleStepMatch(const SingleStepMatch &match) :
-    stepInfo(match.stepInfo),
-    submatches(match.submatches) {
-}
-
-SingleStepMatch & SingleStepMatch::operator =(const SingleStepMatch &match) {
-    stepInfo = match.stepInfo;
-    submatches = match.submatches;
-    return *this;
-}
-
 SingleStepMatch::operator const void *() const {
-    return stepInfo;
+    return stepInfo.get();
 }
 
 MatchResult::operator void *() {

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -36,8 +36,8 @@ SingleStepMatch & SingleStepMatch::operator =(const SingleStepMatch &match) {
     return *this;
 }
 
-SingleStepMatch::operator void *() {
-    return (void *) stepInfo;
+SingleStepMatch::operator const void *() const {
+    return stepInfo;
 }
 
 MatchResult::operator void *() {

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -11,7 +11,7 @@ StepInfo::StepInfo(const std::string &stepMatcher, const std::string source) :
     id = ++currentId;
 }
 
-SingleStepMatch StepInfo::matches(const std::string &stepDescription) {
+SingleStepMatch StepInfo::matches(const std::string &stepDescription) const {
     SingleStepMatch stepMatch;
     shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
     if (regexMatch->matches()) {
@@ -133,7 +133,7 @@ void StepManager::addStep(const boost::shared_ptr<StepInfo>& stepInfo) {
 MatchResult StepManager::stepMatches(const std::string &stepDescription) const {
     MatchResult matchResult;
     for (steps_type::iterator iter = steps().begin(); iter != steps().end(); ++iter) {
-        const boost::shared_ptr<StepInfo>& stepInfo = iter->second;
+        const boost::shared_ptr<const StepInfo>& stepInfo = iter->second;
         SingleStepMatch currentMatch = stepInfo->matches(stepDescription);
         if (currentMatch) {
             matchResult.addMatch(currentMatch);
@@ -142,7 +142,7 @@ MatchResult StepManager::stepMatches(const std::string &stepDescription) const {
     return matchResult;
 }
 
-const boost::shared_ptr<StepInfo>& StepManager::getStep(step_id_type id) {
+const boost::shared_ptr<const StepInfo>& StepManager::getStep(step_id_type id) {
     return steps()[id];
 }
 

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -151,8 +151,8 @@ StepInfo *StepManager::getStep(step_id_type id) {
  * http://www.parashift.com/c++-faq-lite/ctors.html#faq-10.12
  */
 StepManager::steps_type& StepManager::steps() const {
-    static steps_type *steps = new steps_type();
-    return *steps;
+    static steps_type steps;
+    return steps;
 }
 
 

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/hook/Tag.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -13,8 +14,7 @@ AndTagExpression::AndTagExpression(const std::string &csvTagNotation) {
     const RegexMatch::submatches_type submatches = match->getSubmatches();
     for (RegexMatch::submatches_type::const_iterator i = submatches.begin(); i != submatches.end(); ++i) {
         const std::string orCsvTagNotation = i->value;
-        shared_ptr<OrTagExpression> orExpression(new OrTagExpression(orCsvTagNotation));
-        orExpressions.push_back(orExpression);
+        orExpressions.push_back(boost::make_shared<OrTagExpression>(orCsvTagNotation));
     }
 }
 

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -4,6 +4,7 @@
 #include <json_spirit/json_spirit_reader_template.h>
 #include <json_spirit/json_spirit_writer_template.h>
 
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/foreach.hpp>
@@ -195,12 +196,13 @@ public:
     }
 };
 
-static std::map<std::string, boost::shared_ptr<CommandDecoder> > commandDecodersMap = boost::assign::map_list_of
-    ("begin_scenario", boost::shared_ptr<CommandDecoder> (new BeginScenarioDecoder))
-    ("end_scenario", boost::shared_ptr<CommandDecoder> (new EndScenarioDecoder))
-    ("step_matches", boost::shared_ptr<CommandDecoder> (new StepMatchesDecoder))
-    ("invoke", boost::shared_ptr<CommandDecoder> (new InvokeDecoder))
-    ("snippet_text", boost::shared_ptr<CommandDecoder> (new SnippetTextDecoder));
+static std::map<std::string, boost::shared_ptr<CommandDecoder> > commandDecodersMap =
+  boost::assign::map_list_of<std::string, boost::shared_ptr<CommandDecoder> >
+    ("begin_scenario", boost::make_shared< BeginScenarioDecoder >())
+    ("end_scenario"  , boost::make_shared< EndScenarioDecoder   >())
+    ("step_matches"  , boost::make_shared< StepMatchesDecoder   >())
+    ("invoke"        , boost::make_shared< InvokeDecoder        >())
+    ("snippet_text"  , boost::make_shared< SnippetTextDecoder   >());
 
 
 JsonSpiritWireMessageCodec::JsonSpiritWireMessageCodec() {};

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -24,8 +24,8 @@ namespace internal {
  */
 
 
-void SuccessResponse::accept(WireResponseVisitor *visitor) const {
-    visitor->visit(this);
+void SuccessResponse::accept(WireResponseVisitor& visitor) const {
+    visitor.visit(*this);
 }
 
 FailureResponse::FailureResponse(const std::string & message, const std::string & exceptionType) :
@@ -41,8 +41,8 @@ const std::string FailureResponse::getExceptionType() const {
     return exceptionType;
 }
 
-void FailureResponse::accept(WireResponseVisitor *visitor) const {
-    visitor->visit(this);
+void FailureResponse::accept(WireResponseVisitor& visitor) const {
+    visitor.visit(*this);
 }
 
 PendingResponse::PendingResponse(const std::string & message) :
@@ -53,8 +53,8 @@ const std::string PendingResponse::getMessage() const {
     return message;
 }
 
-void PendingResponse::accept(WireResponseVisitor *visitor) const {
-    visitor->visit(this);
+void PendingResponse::accept(WireResponseVisitor& visitor) const {
+    visitor.visit(*this);
 }
 
 StepMatchesResponse::StepMatchesResponse(const std::vector<StepMatch> & matchingSteps)
@@ -65,8 +65,8 @@ const std::vector<StepMatch>& StepMatchesResponse::getMatchingSteps() const {
     return matchingSteps;
 }
 
-void StepMatchesResponse::accept(WireResponseVisitor *visitor) const {
-    visitor->visit(this);
+void StepMatchesResponse::accept(WireResponseVisitor& visitor) const {
+    visitor.visit(*this);
 }
 
 SnippetTextResponse::SnippetTextResponse(const std::string & stepSnippet) :
@@ -77,8 +77,8 @@ const std::string SnippetTextResponse::getStepSnippet() const {
     return stepSnippet;
 }
 
-void SnippetTextResponse::accept(WireResponseVisitor *visitor) const {
-    visitor->visit(this);
+void SnippetTextResponse::accept(WireResponseVisitor& visitor) const {
+    visitor.visit(*this);
 }
 
 
@@ -90,18 +90,18 @@ void SnippetTextResponse::accept(WireResponseVisitor *visitor) const {
 class CommandDecoder {
 public:
   virtual ~CommandDecoder() { }
-  virtual WireCommand *decode(const mValue & jsonArgs) const = 0;
+  virtual boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const = 0;
 };
 
 
 class ScenarioDecoder : public CommandDecoder {
 protected:
-    CukeEngine::tags_type *getTags(const mValue & jsonArgs) const {
-        CukeEngine::tags_type *tags = new CukeEngine::tags_type;
+    CukeEngine::tags_type getTags(const mValue & jsonArgs) const {
+        CukeEngine::tags_type tags;
         if (!jsonArgs.is_null()) {
             const mArray & jsonTags = jsonArgs.get_obj().find("tags")->second.get_array();
             for (mArray::const_iterator i = jsonTags.begin(); i != jsonTags.end(); ++i) {
-                tags->push_back(i->get_str());
+                tags.push_back(i->get_str());
             }
         }
         return tags;
@@ -111,40 +111,40 @@ protected:
 
 class BeginScenarioDecoder : public ScenarioDecoder {
 public:
-    WireCommand *decode(const mValue & jsonArgs) const {
-        return new BeginScenarioCommand(getTags(jsonArgs));
+    boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const {
+        return boost::make_shared<BeginScenarioCommand>(getTags(jsonArgs));
     }
 };
 
 
 class EndScenarioDecoder : public ScenarioDecoder {
 public:
-    WireCommand *decode(const mValue & jsonArgs) const {
-        return new EndScenarioCommand(getTags(jsonArgs));
+    boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const {
+        return boost::make_shared<EndScenarioCommand>(getTags(jsonArgs));
     }
 };
 
 
 class StepMatchesDecoder : public CommandDecoder {
 public:
-    WireCommand *decode(const mValue & jsonArgs) const {
+    boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const {
         mObject stepMatchesArgs(jsonArgs.get_obj());
         const std::string & nameToMatch(stepMatchesArgs["name_to_match"].get_str());
-        return new StepMatchesCommand(nameToMatch);
+        return boost::make_shared<StepMatchesCommand>(nameToMatch);
     }
 };
 
 
 class InvokeDecoder : public CommandDecoder {
 public:
-    WireCommand *decode(const mValue & jsonArgs) const {
+    boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const {
         mObject invokeParams(jsonArgs.get_obj());
 
-        CukeEngine::invoke_args_type *args = new CukeEngine::invoke_args_type;
-        CukeEngine::invoke_table_type *tableArg = new CukeEngine::invoke_table_type;
+        CukeEngine::invoke_args_type args;
+        CukeEngine::invoke_table_type tableArg;
         const std::string & id(invokeParams["id"].get_str());
-        fillInvokeArgs(invokeParams, *args, *tableArg);
-        return new InvokeCommand(id, args, tableArg);
+        fillInvokeArgs(invokeParams, args, tableArg);
+        return boost::make_shared<InvokeCommand>(id, args, tableArg);
     }
 
 private:
@@ -187,12 +187,12 @@ private:
 
 class SnippetTextDecoder : public CommandDecoder {
 public:
-    WireCommand *decode(const mValue & jsonArgs) const {
+    boost::shared_ptr<WireCommand> decode(const mValue & jsonArgs) const {
         mObject snippetTextArgs(jsonArgs.get_obj());
         const std::string & stepKeyword(snippetTextArgs["step_keyword"].get_str());
         const std::string & stepName(snippetTextArgs["step_name"].get_str());
         const std::string & multilineArgClass(snippetTextArgs["multiline_arg_class"].get_str());
-        return new SnippetTextCommand(stepKeyword, stepName, multilineArgClass);
+        return boost::make_shared<SnippetTextCommand>(stepKeyword, stepName, multilineArgClass);
     }
 };
 
@@ -207,7 +207,7 @@ static std::map<std::string, boost::shared_ptr<CommandDecoder> > commandDecoders
 
 JsonSpiritWireMessageCodec::JsonSpiritWireMessageCodec() {};
 
-WireCommand *JsonSpiritWireMessageCodec::decode(const std::string &request) const {
+boost::shared_ptr<WireCommand> JsonSpiritWireMessageCodec::decode(const std::string &request) const {
     std::istringstream is(request);
     mValue json;
     try {
@@ -226,7 +226,7 @@ WireCommand *JsonSpiritWireMessageCodec::decode(const std::string &request) cons
     } catch (...) {
         // LOG Error decoding wire protocol command
     }
-    return new FailingCommand;
+    return boost::make_shared<FailingCommand>();
 }
 
 namespace {
@@ -252,24 +252,24 @@ namespace {
         }
 
     public:
-        std::string encode(const WireResponse *response) {
+        std::string encode(const WireResponse& response) {
             jsonOutput.clear();
-            response->accept(this);
+            response.accept(*this);
             const mValue v(jsonOutput);
             return write_string(v, false);
         }
 
-        void visit(const SuccessResponse* /*response*/) {
+        void visit(const SuccessResponse& /*response*/) {
             success();
         }
 
-        void visit(const FailureResponse *response) {
+        void visit(const FailureResponse& response) {
             mObject detailObject;
-            if (!response->getMessage().empty()) {
-                detailObject["message"] = response->getMessage();
+            if (!response.getMessage().empty()) {
+                detailObject["message"] = response.getMessage();
             }
-            if (!response->getExceptionType().empty()) {
-                detailObject["exception"] = response->getExceptionType();
+            if (!response.getExceptionType().empty()) {
+                detailObject["exception"] = response.getExceptionType();
             }
             if (detailObject.empty()) {
                 fail();
@@ -279,14 +279,14 @@ namespace {
             }
         }
 
-        void visit(const PendingResponse *response) {
-            mValue jsonReponse(response->getMessage());
+        void visit(const PendingResponse& response) {
+            mValue jsonReponse(response.getMessage());
             output("pending", &jsonReponse);
         }
 
-        void visit(const StepMatchesResponse *response) {
+        void visit(const StepMatchesResponse& response) {
             mArray jsonMatches;
-            BOOST_FOREACH(StepMatch m, response->getMatchingSteps()) {
+            BOOST_FOREACH(StepMatch m, response.getMatchingSteps()) {
                 mObject jsonM;
                 jsonM["id"] = m.id;
                 mArray jsonArgs;
@@ -309,15 +309,15 @@ namespace {
             output("success", &jsonReponse);
         }
 
-        void visit(const SnippetTextResponse *response) {
-            mValue jsonReponse(response->getStepSnippet());
+        void visit(const SnippetTextResponse& response) {
+            mValue jsonReponse(response.getStepSnippet());
             success(&jsonReponse);
         }
     };
 
 }
 
-const std::string JsonSpiritWireMessageCodec::encode(const WireResponse *response) const {
+const std::string JsonSpiritWireMessageCodec::encode(const WireResponse& response) const {
     try {
         WireResponseEncoder encoder;
         return encoder.encode(response);
@@ -326,7 +326,7 @@ const std::string JsonSpiritWireMessageCodec::encode(const WireResponse *respons
     }
 }
 
-WireProtocolHandler::WireProtocolHandler(const WireMessageCodec *codec, CukeEngine *engine) :
+WireProtocolHandler::WireProtocolHandler(const WireMessageCodec& codec, CukeEngine& engine) :
     codec(codec),
     engine(engine) {
 }
@@ -335,9 +335,9 @@ std::string WireProtocolHandler::handle(const std::string &request) const {
     std::string response;
     // LOG request
     try {
-        const WireCommand *command = codec->decode(request);
-        const WireResponse *wireResponse = command->run(engine);
-        response = codec->encode(wireResponse);
+        boost::shared_ptr<const WireCommand> command = codec.decode(request);
+        boost::shared_ptr<const WireResponse> wireResponse = command->run(engine);
+        response = codec.encode(*wireResponse);
     } catch (...) {
         response = "[\"fail\"]";
     }

--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -1,30 +1,31 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp>
+#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
 
-ScenarioCommand::ScenarioCommand(const CukeEngine::tags_type *tags) :
+ScenarioCommand::ScenarioCommand(const CukeEngine::tags_type& tags) :
     tags(tags) {
 }
 
 
-BeginScenarioCommand::BeginScenarioCommand(const CukeEngine::tags_type *tags) :
+BeginScenarioCommand::BeginScenarioCommand(const CukeEngine::tags_type& tags) :
     ScenarioCommand(tags) {
 }
 
-WireResponse *BeginScenarioCommand::run(CukeEngine *engine) const {
-    engine->beginScenario(*tags);
-    return new SuccessResponse;
+boost::shared_ptr<WireResponse> BeginScenarioCommand::run(CukeEngine& engine) const {
+    engine.beginScenario(tags);
+    return boost::make_shared<SuccessResponse>();
 }
 
 
-EndScenarioCommand::EndScenarioCommand(const CukeEngine::tags_type *tags) :
+EndScenarioCommand::EndScenarioCommand(const CukeEngine::tags_type& tags) :
     ScenarioCommand(tags) {
 }
 
-WireResponse *EndScenarioCommand::run(CukeEngine *engine) const {
-    engine->endScenario(*tags);
-    return new SuccessResponse;
+boost::shared_ptr<WireResponse> EndScenarioCommand::run(CukeEngine& engine) const {
+    engine.endScenario(tags);
+    return boost::make_shared<SuccessResponse>();
 }
 
 
@@ -32,30 +33,30 @@ StepMatchesCommand::StepMatchesCommand(const std::string & stepName) :
     stepName(stepName) {
 }
 
-WireResponse *StepMatchesCommand::run(CukeEngine *engine) const {
-    std::vector<StepMatch> matchingSteps = engine->stepMatches(stepName);
-    return new StepMatchesResponse(matchingSteps);
+boost::shared_ptr<WireResponse> StepMatchesCommand::run(CukeEngine& engine) const {
+    std::vector<StepMatch> matchingSteps = engine.stepMatches(stepName);
+    return boost::make_shared<StepMatchesResponse>(matchingSteps);
 }
 
 
 InvokeCommand::InvokeCommand(const std::string & stepId,
-                             const CukeEngine::invoke_args_type *args,
-                             const CukeEngine::invoke_table_type * tableArg) :
+                             const CukeEngine::invoke_args_type& args,
+                             const CukeEngine::invoke_table_type& tableArg) :
     stepId(stepId),
     args(args),
     tableArg(tableArg) {
 }
 
-WireResponse *InvokeCommand::run(CukeEngine *engine) const {
+boost::shared_ptr<WireResponse> InvokeCommand::run(CukeEngine& engine) const {
     try {
-        engine->invokeStep(stepId, *args, *tableArg);
-        return new SuccessResponse;
+        engine.invokeStep(stepId, args, tableArg);
+        return boost::make_shared<SuccessResponse>();
     } catch (const InvokeFailureException& e) {
-        return new FailureResponse(e.getMessage(), e.getExceptionType());
+        return boost::make_shared<FailureResponse>(e.getMessage(), e.getExceptionType());
     } catch (const PendingStepException& e) {
-        return new PendingResponse(e.getMessage());
+        return boost::make_shared<PendingResponse>(e.getMessage());
     } catch (...) {
-        return new FailureResponse;
+        return boost::make_shared<FailureResponse>();
     }
 }
 
@@ -66,13 +67,13 @@ SnippetTextCommand::SnippetTextCommand(const std::string & keyword, const std::s
     multilineArgClass(multilineArgClass) {
 }
 
-WireResponse *SnippetTextCommand::run(CukeEngine *engine) const {
-    return new SnippetTextResponse(engine->snippetText(keyword, name, multilineArgClass));
+boost::shared_ptr<WireResponse> SnippetTextCommand::run(CukeEngine& engine) const {
+    return boost::make_shared<SnippetTextResponse>(engine.snippetText(keyword, name, multilineArgClass));
 }
 
 
-WireResponse *FailingCommand::run(CukeEngine* /*engine*/) const {
-    return new FailureResponse;
+boost::shared_ptr<WireResponse> FailingCommand::run(CukeEngine& /*engine*/) const {
+    return boost::make_shared<FailureResponse>();
 }
 
 }

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_log_formatter.hpp>
 #include <boost/thread/once.hpp>
@@ -35,6 +36,7 @@ bool boost_test_init() {
     return true;
 }
 
+// Freed by Boost's unit test framework on exit
 static CukeBoostLogInterceptor *logInterceptor = 0;
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ void acceptWireProtocol(int port, const std::string& unixPath, bool verbose) {
     using namespace ::cucumber::internal;
     CukeEngineImpl cukeEngine;
     JsonSpiritWireMessageCodec wireCodec;
-    WireProtocolHandler protocolHandler(&wireCodec, &cukeEngine);
+    WireProtocolHandler protocolHandler(wireCodec, cukeEngine);
     boost::scoped_ptr<SocketServer> server;
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
     if (!unixPath.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ function(cuke_add_driver_test TEST_FILE)
     message(STATUS "Adding " ${TEST_NAME})
     add_executable(${TEST_NAME} ${TEST_FILE}.cpp)
     target_link_libraries(${TEST_NAME} cucumber-cpp-nomain ${CUKE_EXTRA_LIBRARIES} ${ARGN})
-    add_test(${TEST_NAME} ${TEST_NAME})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endfunction()
 
 if(GMOCK_FOUND)

--- a/tests/integration/HookRegistrationTest.cpp
+++ b/tests/integration/HookRegistrationTest.cpp
@@ -98,7 +98,7 @@ const std::string correctAfterAllOrder(AFTER_ALL_MARKER_1 AFTER_ALL_MARKER_2 AFT
 
 
 TEST_F(HookRegistrationTest, hooksAreRegisteredByTheMacros) {
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ(correctBeforeOrder, sort(beforeHookOrder()));
     EXPECT_EQ(correctBeforeAroundStepOrder, sort(aroundStepHookOrder()));
     EXPECT_EQ(correctAfterStepOrder, sort(afterStepHookOrder()));
@@ -108,7 +108,7 @@ TEST_F(HookRegistrationTest, hooksAreRegisteredByTheMacros) {
 
 TEST_F(HookRegistrationTest, beforeHooksAreInvokedInAnyOrder) {
     EXPECT_EQ("", beforeHookCallMarker.str());
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ(correctBeforeOrder, sort(beforeHookCallMarker.str()));
     invokeStep();
     endScenario();
@@ -116,7 +116,7 @@ TEST_F(HookRegistrationTest, beforeHooksAreInvokedInAnyOrder) {
 }
 
 TEST_F(HookRegistrationTest, aroundStepHooksAreInvokedInAnyOrderButNested) {
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ("", beforeAroundStepHookCallMarker.str());
     invokeStep();
     EXPECT_EQ(correctBeforeAroundStepOrder, sort(beforeAroundStepHookCallMarker.str()));
@@ -127,7 +127,7 @@ TEST_F(HookRegistrationTest, aroundStepHooksAreInvokedInAnyOrderButNested) {
 }
 
 TEST_F(HookRegistrationTest, afterStepHooksAreInvokedInAnyOrder) {
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ("", afterStepHookCallMarker.str());
     invokeStep();
     EXPECT_EQ(correctAfterStepOrder, sort(afterStepHookCallMarker.str()));
@@ -136,7 +136,7 @@ TEST_F(HookRegistrationTest, afterStepHooksAreInvokedInAnyOrder) {
 }
 
 TEST_F(HookRegistrationTest, afterHooksAreInvokedInAnyOrder) {
-    beginScenario(0);
+    beginScenario();
     invokeStep();
     invokeStep();
     EXPECT_EQ("", sort(afterHookCallMarker.str()));
@@ -145,13 +145,13 @@ TEST_F(HookRegistrationTest, afterHooksAreInvokedInAnyOrder) {
 }
 
 TEST_F(HookRegistrationTest, contextIsAccessibleInAfterHooks) {
-    beginScenario(0);
+    beginScenario();
     endScenario();
     EXPECT_EQ(CONTEXT_MARKER, contextContents);
 }
 
 TEST_F(HookRegistrationTest, afterStepHooksAreInvokedAfterAroundStepHooks) {
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ("", globalStepHookCallMarker.str());
     invokeStep();
     EXPECT_EQ(beforeAroundStepHookCallMarker.str() +
@@ -163,14 +163,14 @@ TEST_F(HookRegistrationTest, afterStepHooksAreInvokedAfterAroundStepHooks) {
 
 TEST_F(HookRegistrationTest, beforeAllHooksAreInvokedInAnyOrderDuringFirstScenarioOnly) {
     EXPECT_EQ("", afterAllHookCallMarker.str());
-    beginScenario(0);
+    beginScenario();
     EXPECT_EQ(correctBeforeAllOrder, sort(beforeAllHookCallMarker.str()));
     
     clearHookCallMarkers();
     invokeStep();
     endScenario();
     EXPECT_EQ("", sort(beforeAllHookCallMarker.str()));
-    beginScenario(0);
+    beginScenario();
     invokeStep();
     endScenario();
     EXPECT_EQ("", sort(beforeAllHookCallMarker.str()));
@@ -203,10 +203,10 @@ TEST_F(HookRegistrationTest, afterAllHooksAreInvokedOnceDuringDestructionOnly) {
     CukeCommands* cukeCommands = new CukeCommands();
 
     EXPECT_EQ("", afterAllHookCallMarker.str());
-    cukeCommands->beginScenario(0);
+    cukeCommands->beginScenario();
     cukeCommands->endScenario();
     EXPECT_EQ("", afterAllHookCallMarker.str());
-    cukeCommands->beginScenario(0);
+    cukeCommands->beginScenario();
     cukeCommands->endScenario();
     EXPECT_EQ("", afterAllHookCallMarker.str());
 

--- a/tests/integration/TaggedHookRegistrationTest.cpp
+++ b/tests/integration/TaggedHookRegistrationTest.cpp
@@ -24,7 +24,7 @@ AFTER("@a,@b") { afterHookCallMarker << "L"; }
 
 
 TEST_F(HookRegistrationTest, noTaggedHooksAreInvokedIfNoScenarioTag) {
-    beginScenario(0);
+    beginScenario();
     invokeStep();
     endScenario();
     EXPECT_EQ("", sort(beforeHookCallMarker.str()));

--- a/tests/unit/CukeCommandsTest.cpp
+++ b/tests/unit/CukeCommandsTest.cpp
@@ -3,6 +3,9 @@
 #include <cucumber-cpp/internal/step/StepMacros.hpp>
 #include "../utils/CukeCommandsFixture.hpp"
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 using namespace cucumber::internal;
 
 using std::string;
@@ -23,8 +26,8 @@ protected:
     static const string arg_3_string_with_spaces;
 
 public:
-    static InvokeArgs *buildInvokeArgs() {
-        InvokeArgs *mixedArgs = new InvokeArgs;
+    static boost::shared_ptr<InvokeArgs> buildInvokeArgs() {
+        boost::shared_ptr<InvokeArgs> mixedArgs(boost::make_shared<InvokeArgs>());
         mixedArgs->addArg(toString(arg_0_int));
         mixedArgs->addArg(toString(arg_1_double));
         mixedArgs->addArg(toString(arg_2_string));

--- a/tests/unit/StepCallChainTest.cpp
+++ b/tests/unit/StepCallChainTest.cpp
@@ -73,8 +73,8 @@ protected:
     std::stringstream markers;
 
     InvokeResult execStep(const InvokeResult &result) {
-        FakeStepInfo step(&markers, result);
-        StepCallChain scc(0, &step, &NO_INVOKE_ARGS, aroundHooks);
+        boost::shared_ptr<FakeStepInfo> step(boost::make_shared<FakeStepInfo>(&markers, result));
+        StepCallChain scc(0, step, &NO_INVOKE_ARGS, aroundHooks);
         return scc.exec();
     }
 
@@ -88,34 +88,36 @@ protected:
 };
 
 TEST_F(StepCallChainTest, failsIfNoStep) {
-    StepCallChain scc(0, 0, &NO_INVOKE_ARGS, aroundHooks);
+    StepCallChain scc(0, boost::shared_ptr<StepInfo>(), &NO_INVOKE_ARGS, aroundHooks);
     EXPECT_FALSE(scc.exec().isSuccess());
     EXPECT_EQ("", markers.str());
 }
 
 TEST_F(StepCallChainTest, stepExecutionReturnsTheExpectedResult) {
-    MarkingAroundStepHook hook;
+    boost::shared_ptr<MarkingAroundStepHook> hook(boost::make_shared<MarkingAroundStepHook>());
 
     execStepAndCheckSuccess();
 
-    aroundHooks.push_back(&hook);
+    aroundHooks.push_back(hook);
 
     execStepAndCheckSuccess();
 
-    aroundHooks.push_back(&hook);
-    aroundHooks.push_back(&hook);
+    aroundHooks.push_back(hook);
+    aroundHooks.push_back(hook);
 
     execStepAndCheckSuccess();
 }
 
 TEST_F(StepCallChainTest, aroundHooksAreInvokedInTheCorrectOrder) {
-    MarkingAroundStepHook hook1("1", &markers);
-    MarkingAroundStepHook hook2("2", &markers);
-    MarkingAroundStepHook hook3("3", &markers);
+    boost::shared_ptr<MarkingAroundStepHook>
+        hook1(boost::make_shared<MarkingAroundStepHook>("1", &markers))
+      , hook2(boost::make_shared<MarkingAroundStepHook>("2", &markers))
+      , hook3(boost::make_shared<MarkingAroundStepHook>("3", &markers))
+      ;
 
-    aroundHooks.push_back(&hook1);
-    aroundHooks.push_back(&hook2);
-    aroundHooks.push_back(&hook3);
+    aroundHooks.push_back(hook1);
+    aroundHooks.push_back(hook2);
+    aroundHooks.push_back(hook3);
 
     execStep(InvokeResult::success());
 
@@ -123,22 +125,24 @@ TEST_F(StepCallChainTest, aroundHooksAreInvokedInTheCorrectOrder) {
 }
 
 TEST_F(StepCallChainTest, argsArePassedToTheStep) {
-    FakeStepInfo step(&markers, InvokeResult::success());
-    StepCallChain scc(0, &step, &NO_INVOKE_ARGS, aroundHooks);
+    boost::shared_ptr<FakeStepInfo> step(boost::make_shared<FakeStepInfo>(&markers, InvokeResult::success()));
+    StepCallChain scc(0, step, &NO_INVOKE_ARGS, aroundHooks);
 
-    EXPECT_NE(&NO_INVOKE_ARGS, step.getLatestArgsPassed());
+    EXPECT_NE(&NO_INVOKE_ARGS, step->getLatestArgsPassed());
     scc.exec();
-    EXPECT_EQ(&NO_INVOKE_ARGS, step.getLatestArgsPassed());
+    EXPECT_EQ(&NO_INVOKE_ARGS, step->getLatestArgsPassed());
 }
 
 TEST_F(StepCallChainTest, aroundHooksCanStopTheCallChain) {
-    MarkingAroundStepHook hook1("1", &markers);
-    BlockingAroundStepHook hook2("2", &markers);
-    MarkingAroundStepHook hook3("3", &markers);
+    boost::shared_ptr<MarkingAroundStepHook>
+        hook1(boost::make_shared<MarkingAroundStepHook >("1", &markers))
+      , hook2(boost::make_shared<BlockingAroundStepHook>("2", &markers))
+      , hook3(boost::make_shared<MarkingAroundStepHook >("3", &markers))
+      ;
 
-    aroundHooks.push_back(&hook1);
-    aroundHooks.push_back(&hook2);
-    aroundHooks.push_back(&hook3);
+    aroundHooks.push_back(hook1);
+    aroundHooks.push_back(hook2);
+    aroundHooks.push_back(hook3);
 
     execStep(InvokeResult::success());
 

--- a/tests/unit/StepCallChainTest.cpp
+++ b/tests/unit/StepCallChainTest.cpp
@@ -13,7 +13,7 @@ public:
         result(result) {
     }
 
-    InvokeResult invokeStep(const InvokeArgs *pArgs) {
+    InvokeResult invokeStep(const InvokeArgs *pArgs) const {
         latestArgsPtr = pArgs;
         (*markersPtr) << "S";
         return result;
@@ -24,7 +24,7 @@ public:
     }
 
 private:
-    const InvokeArgs *latestArgsPtr;
+    mutable const InvokeArgs *latestArgsPtr;
     std::stringstream *markersPtr;
     const InvokeResult result;
 };

--- a/tests/utils/CukeCommandsFixture.hpp
+++ b/tests/utils/CukeCommandsFixture.hpp
@@ -27,7 +27,7 @@ protected:
     void runStepBodyTest() {
         addStepToManager<T>(STATIC_MATCHER);
         shared_ptr<const InvokeArgs> spArgs(T::buildInvokeArgs());
-        invoke(stepInfoPtr->id, spArgs);
+        invoke(stepInfoPtr->id, spArgs.get());
     }
 
     template<class T>

--- a/tests/utils/CukeCommandsFixture.hpp
+++ b/tests/utils/CukeCommandsFixture.hpp
@@ -5,6 +5,7 @@
 #include <cucumber-cpp/internal/drivers/GenericDriver.hpp>
 #include "StepManagerTestDouble.hpp"
 
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 
 using namespace cucumber::internal;
@@ -25,15 +26,14 @@ protected:
     template<class T>
     void runStepBodyTest() {
         addStepToManager<T>(STATIC_MATCHER);
-        const InvokeArgs *pArgs = T::buildInvokeArgs();
-        shared_ptr<const InvokeArgs> spArgs(pArgs);
-        invoke(stepInfoPtr->id, pArgs);
+        shared_ptr<const InvokeArgs> spArgs(T::buildInvokeArgs());
+        invoke(stepInfoPtr->id, spArgs);
     }
 
     template<class T>
     void addStepToManager(const std::string &matcher) {
-        stepInfoPtr = shared_ptr<StepInfo>(new StepInvoker<T>(matcher, ""));
-        stepManager.addStep(stepInfoPtr.get());
+        stepInfoPtr = boost::make_shared< StepInvoker<T> >(matcher, "");
+        stepManager.addStep(stepInfoPtr);
     }
 
     virtual void TearDown() {

--- a/tests/utils/DriverTestRunner.hpp
+++ b/tests/utils/DriverTestRunner.hpp
@@ -113,7 +113,7 @@ private:
 
         InvokeResult result;
 
-        cukeCommands.beginScenario(0);
+        cukeCommands.beginScenario();
 
         result = cukeCommands.invoke(getStepIdFromMatcher(SUCCEED_MATCHER), &NO_INVOKE_ARGS);
         expectTrue("Succeeding step", result.isSuccess());
@@ -145,7 +145,7 @@ private:
     void contextConstructorAndDesctructorGetCalledOn(const std::string stepMatcher) {
         std::cout << "== " << stepMatcher << " ==" << std::endl;
         listener.reset();
-        cukeCommands.beginScenario(0);
+        cukeCommands.beginScenario();
         cukeCommands.invoke(getStepIdFromMatcher(stepMatcher), &NO_INVOKE_ARGS);
         expectEqual("Contexts created after invoke", 1, listener.getCreatedContexts());
         expectEqual("Contexts destroyed after invoke", 0, listener.getDestroyedContexts());
@@ -157,7 +157,7 @@ private:
     void failureDescriptionIsResetOnEachRun() {
         std::cout << "= Step failure description is reset =" << std::endl;
         InvokeResult result;
-        cukeCommands.beginScenario(0);
+        cukeCommands.beginScenario();
 
         result = cukeCommands.invoke(getStepIdFromMatcher(FAIL_MATCHER), &NO_INVOKE_ARGS);
         std::string failureMessage = result.getDescription();

--- a/tests/utils/HookRegistrationFixture.hpp
+++ b/tests/utils/HookRegistrationFixture.hpp
@@ -5,6 +5,7 @@
 
 #include "CukeCommandsFixture.hpp"
 
+#include <boost/make_shared.hpp>
 #include <sstream>
 
 using namespace cucumber::internal;
@@ -67,7 +68,7 @@ protected:
     shared_ptr<Scenario> emptyScenario;
 
     HookRegistrationTest() {
-        emptyScenario = shared_ptr<Scenario>(new Scenario(new TagExpression::tag_list));
+        emptyScenario = boost::make_shared<Scenario>(new TagExpression::tag_list);
     }
 
     Scenario *getEmptyScenario() {

--- a/tests/utils/HookRegistrationFixture.hpp
+++ b/tests/utils/HookRegistrationFixture.hpp
@@ -68,7 +68,7 @@ protected:
     shared_ptr<Scenario> emptyScenario;
 
     HookRegistrationTest() {
-        emptyScenario = boost::make_shared<Scenario>(new TagExpression::tag_list);
+        emptyScenario = boost::make_shared<Scenario>();
     }
 
     Scenario *getEmptyScenario() {
@@ -99,13 +99,8 @@ protected:
         return getHookCallMarkers();
     }
 
-    void beginScenario(const TagExpression::tag_list *tags) {
+    void beginScenario(const TagExpression::tag_list & tags = TagExpression::tag_list()) {
         CukeCommandsFixture::beginScenario(tags);
-    }
-
-    void beginScenario(const TagExpression::tag_list & tags) {
-        TagExpression::tag_list *pTags = new TagExpression::tag_list(tags.begin(), tags.end());
-        CukeCommandsFixture::beginScenario(pTags);
     }
 
     void invokeStep() {

--- a/tests/utils/StepManagerTestDouble.hpp
+++ b/tests/utils/StepManagerTestDouble.hpp
@@ -10,7 +10,7 @@ namespace internal {
 class StepInfoNoOp : public StepInfo {
 public:
     StepInfoNoOp(const std::string &stepMatcher, const std::string source) : StepInfo(stepMatcher, source) {}
-    InvokeResult invokeStep(const InvokeArgs *pArgs) {
+    InvokeResult invokeStep(const InvokeArgs *pArgs) const {
         return InvokeResult::success();
     }
 };
@@ -24,7 +24,7 @@ public:
         description(description) {
     }
 
-    InvokeResult invokeStep(const InvokeArgs *pArgs) {
+    InvokeResult invokeStep(const InvokeArgs *pArgs) const {
         return InvokeResult::pending(description);
     }
 };
@@ -40,7 +40,7 @@ public:
         expectedSize(expectedSize) {
     }
 
-    InvokeResult invokeStep(const InvokeArgs *pArgs) {
+    InvokeResult invokeStep(const InvokeArgs *pArgs) const {
         if (pArgs->getTableArg().hashes().size() == expectedSize) {
             return InvokeResult::success();
         } else {
@@ -97,7 +97,7 @@ public:
     const step_id_type getStepId(const std::string &stepMatcher) {
         step_id_type id = 0;
         for (steps_type::const_iterator i = steps().begin(); i != steps().end(); ++i) {
-            const boost::shared_ptr<StepInfo>& stepInfo = i->second;
+            const boost::shared_ptr<const StepInfo>& stepInfo = i->second;
             if (stepInfo->regex.str() == stepMatcher) {
                 id = stepInfo->id;
                 break;

--- a/tests/utils/StepManagerTestDouble.hpp
+++ b/tests/utils/StepManagerTestDouble.hpp
@@ -61,7 +61,7 @@ public:
     }
 
     step_id_type addStepDefinition(const std::string &stepMatcher) {
-        StepInfo *stepInfo = new StepInfoNoOp(stepMatcher, "");
+        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoNoOp>(stepMatcher, ""));
         addStep(stepInfo);
         return stepInfo->id;
     }
@@ -72,7 +72,7 @@ public:
 
     void addStepDefinitionWithId(step_id_type desiredId, const std::string &stepMatcher,
             const std::string source) {
-        StepInfo *stepInfo = new StepInfoNoOp(stepMatcher, source);
+        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoNoOp>(stepMatcher, source));
         stepInfo->id = desiredId;
         addStep(stepInfo);
     }
@@ -83,13 +83,13 @@ public:
 
     void addPendingStepDefinitionWithId(step_id_type desiredId,
             const std::string &stepMatcher, const char *description) {
-        StepInfo *stepInfo = new StepInfoPending(stepMatcher, description);
+        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoPending>(stepMatcher, description));
         stepInfo->id = desiredId;
         addStep(stepInfo);
     }
 
     void addTableStepDefinitionWithId(step_id_type desiredId, const std::string &stepMatcher, const unsigned short expectedSize) {
-        StepInfo *stepInfo = new StepInfoWithTableArg(stepMatcher, expectedSize);
+        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoWithTableArg>(stepMatcher, expectedSize));
         stepInfo->id = desiredId;
         addStep(stepInfo);
     }
@@ -97,7 +97,7 @@ public:
     const step_id_type getStepId(const std::string &stepMatcher) {
         step_id_type id = 0;
         for (steps_type::const_iterator i = steps().begin(); i != steps().end(); ++i) {
-            StepInfo *stepInfo = i->second;
+            const boost::shared_ptr<StepInfo>& stepInfo = i->second;
             if (stepInfo->regex.str() == stepMatcher) {
                 id = stepInfo->id;
                 break;

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e #break script on non-zero exitcode from any command
+set -x #display command being executed
 gem install bundler
 bundle install
 
@@ -10,6 +11,7 @@ cmake -E make_directory build
 cmake -E chdir build cmake \
     -G Ninja \
     -DCUKE_ENABLE_EXAMPLES=on \
+    ${VALGRIND_TESTS:+"-DVALGRIND_TESTS=${VALGRIND_TESTS}"} \
     ${GMOCK_PATH:-"-DGMOCK_VER=${GMOCK_VER}"} \
     ${GMOCK_PATH:+"-DGMOCK_SRC_DIR=${GMOCK_PATH}"} \
     ..


### PR DESCRIPTION
In short this change does these things:
 * Adds running of the unit tests with valgrind which can be enabled with the CMake parameter `-DVALGRIND_TESTS=ON`
 * Add another job on Travis which uses this
 * Reduce memory allocations
 * Don't use dynamically allocated memory for global variables
   - i.e. don't store them as global pointers, instead store them globally by-value
   - this still doesn't suffer from the mentioned static-initialisation-order fiasco, because that only applies to namespace- and class-scoped variables, not function-scoped static variables
 * Remove all uses of `new` in favor of `make_shared` in `src/`, except for:
   - when we're building a `scoped_ptr` (which lacks such a factory function)
   - the log interceptor for Boost's test driver, because that test driver assumes responsibility for deallocation of the logger
 * Make ownership a lot clearer: use references where no ownership is involved if possible, smart pointers where it is