### PR TITLE
Remove email notifications from CI to the Google Group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,8 @@ before_install:
 
 script: ./travis.sh 
 
-notifications:
-  email:
-    - cukes-devs@googlegroups.com
-
 branches:
   only:
     - master
+
+# default notifications: https://docs.travis-ci.com/user/notifications#Notifications

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ branches:
 notifications:
 - provider: Email
   to:
-  - cukes-devs@googlegroups.com
+  - '{{commitAuthorEmail}}'
   on_build_success: false
   on_build_failure: true
   on_build_status_changed: true


### PR DESCRIPTION
Removed email notification from the CI build to stop flooding the [cukes-devs](https://groups.google.com/forum/#!forum/cukes-devs) group with dozens of build messages from private repos.