### PR TITLE
Get rid of clang warning - fix for issue 119

### DIFF
--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -21,9 +21,6 @@ public:
     MOCK_CONST_METHOD3(snippetText, std::string(const std::string & keyword, const std::string & name, const std::string & multilineArgClass));
 };
 
-#define EXPECT_TYPE(classname, expression) \
-    EXPECT_THAT(typeid(classname).name(), StrEq(typeid(expression).name()))
-
 #define EXPECT_PTRTYPE(classname, expression) \
     EXPECT_NE(dynamic_cast<const classname*>(expression), (void*)NULL)
 

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -25,9 +25,7 @@ public:
     EXPECT_THAT(typeid(classname).name(), StrEq(typeid(expression).name()))
 
 #define EXPECT_PTRTYPE(classname, expression) \
-    EXPECT_TYPE(classname, *expression)
-
-
+    EXPECT_NE(dynamic_cast<const classname*>(expression), (void*)NULL)
 
 class WireMessageCodecTest : public Test {
 public:


### PR DESCRIPTION
This change removes CLang warning about typeid on pointer, so fixes issue #119 