### PR TITLE
Enable Qt framework in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 os:
-  - osx
   - linux
 sudo: required
 dist: trusty
@@ -13,14 +12,19 @@ env:
   - GMOCK_PATH=/usr/src/gmock #1.6.0 from ubuntu trusty repo
 matrix:
   exclude:
-    - os: osx
-      env: GMOCK_PATH=/usr/src/gmock
-    - os: osx
-      compiler: gcc #does anyone on osx use it?
+    - os: linux
+      compiler: gcc
+      env: GMOCK_VER=1.8.0
   include:
     - os: linux
       compiler: gcc
       env: GMOCK_VER=1.8.0 VALGRIND_TESTS=ON
+    - os: osx
+      compiler: clang
+      env: GMOCK_VER=1.8.0 QTDIR=/usr/local/Cellar/qt5/5.8.0_1
+    - os: osx
+      compiler: clang
+      env: GMOCK_VER=1.7.0 QTDIR=/usr/local/Cellar/qt5/5.8.0_1
 
 addons:
   apt:
@@ -35,9 +39,10 @@ addons:
       - google-mock
       - ninja-build
       - valgrind
+      - qtbase5-dev
 
 before_install:
-  - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then brew update && brew install ninja; fi
+  - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then brew update && brew install ninja && brew install qt5; fi
 
 script: ./travis.sh 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ set(CUKE_ENABLE_EXAMPLES OFF CACHE BOOL "Enable the examples")
 set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise downloaded)")
 set(GMOCK_VER "1.7.0" CACHE STRING "Google Mock framework version to be used")
 option(VALGRIND_TESTS "Run tests within Valgrind" OFF)
+set(CUKE_DISABLE_QT OFF CACHE BOOL "Disable using Qt framework")
 
+set(ignoreMe "${QT_QMAKE_EXECUTABLE}") #supress warning
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 #
@@ -104,6 +106,34 @@ if(NOT CUKE_DISABLE_GTEST)
 endif()
 
 #
+# Qt
+#
+
+if(NOT CUKE_DISABLE_QT)
+    set(CMAKE_PREFIX_PATH $ENV{QTDIR})
+    find_package(Qt5Core  QUIET)
+    find_package(Qt5Widgets  QUIET)
+    find_package(Qt5Test  QUIET)
+
+    if(${Qt5Core_FOUND} AND ${Qt5Widgets_FOUND} AND ${Qt5Test_FOUND})
+        message(STATUS "Found Qt version: ${Qt5Core_VERSION_STRING}")
+        include_directories(${Qt5Core_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS} ${Qt5Test_INCLUDE_DIRS})
+#        set(CMAKE_INCLUDE_CURRENT_DIR ON)
+#        set(CMAKE_AUTOMOC ON)
+        if (Qt5_POSITION_INDEPENDENT_CODE)
+            SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+        endif()
+        set(QT_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Test)
+    else()
+        find_package(Qt4 COMPONENTS QtCore QtGui QtTest)
+        if(QT4_FOUND)
+            set(QT_LIBRARIES Qt4::QtCore Qt4::QtGui Qt4::QtTest)
+            include(${QT_USE_FILE})
+        endif()
+    endif()
+endif()
+
+#
 # Valgrind
 #
 
@@ -154,11 +184,8 @@ endif()
 #
 
 set(CUKE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
-
 include_directories(${CUKE_INCLUDE_DIR})
-
 set(CUKE_LIBRARIES cucumber-cpp ${CUKE_EXTRA_LIBRARIES})
-
 add_subdirectory(src)
 
 #
@@ -222,4 +249,16 @@ endif()
 
 if(CUKE_ENABLE_EXAMPLES)
     add_subdirectory(examples)
+
+    #check if c++11 is nedded
+    if(${Qt5Core_FOUND})
+        find_program(QMAKE_EXECUTABLE NAMES qmake HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+        execute_process(COMMAND ${QMAKE_EXECUTABLE} -query QT_VERSION OUTPUT_VARIABLE QT_VERSION)
+        if(QT_VERSION GREATER 5.6.99)
+            message(STATUS "C++11 is needed from Qt version 5.7.0, building with c++11 enabled")
+            set_property(TARGET libcalcqt PROPERTY CXX_STANDARD 11)
+            set_property(TARGET calcqt PROPERTY CXX_STANDARD 11)
+        endif()
+    endif()
 endif()
+

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -1,0 +1,20 @@
+set PATH=C:\Ruby200\bin;%BOOST_LIBRARYDIR%;%PATH%
+if defined MINGW_ROOT set PATH=%MINGW_ROOT%\bin;C:\msys64\usr\bin\;%PATH%
+if defined QT_DIR set PATH=%QT_DIR%\bin;%PATH%
+if "%CMAKE_GENERATOR%"=="NMake Makefiles" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
+echo %PATH%
+
+git submodule init
+git submodule update
+call gem install bundle
+call bundle install
+if defined MINGW_ARCH bash -lc "pacman --needed --noconfirm -S mingw-w64-%MINGW_ARCH%-boost
+
+cmake -E make_directory build
+cmake -E chdir build cmake -G "%CMAKE_GENERATOR%" -DCUKE_ENABLE_EXAMPLES=on -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DQT_QMAKE_EXECUTABLE="%QT_DIR%/bin/qmake.exe" ..
+cmake --build build
+
+set CTEST_OUTPUT_ON_FAILURE=ON
+cmake --build build --target test
+cmake --build build --target features
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,59 +2,35 @@ version: "{branch}-ci-{build}"
 os: Visual Studio 2015
 
 environment:
-  RUBY_VERSION: 200
   matrix:
-  - build: mingw
-    platform: x86
+  - CMAKE_GENERATOR: 'MSYS Makefiles'
     MINGW_ARCH: i686
-    MSYSTEM: MINGW32
     MINGW_ROOT: C:\msys64\mingw32
     BOOST_ROOT: C:\msys64\mingw32
     BOOST_LIBRARYDIR: C:\msys64\mingw32\lib
     BOOST_INCLUDEDIR: C:\msys64\mingw32\include\boost
-    CMAKE_GENERATOR: 'MSYS Makefiles'
-  - build: mingw
-    platform: x64
+    QT_DIR: C:\Qt\5.8\mingw53_32
+  - CMAKE_GENERATOR: 'MSYS Makefiles'
     MINGW_ARCH: x86_64
-    MSYSTEM: MINGW64
     MINGW_ROOT: C:\msys64\mingw64
     BOOST_ROOT: C:\msys64\mingw64
     BOOST_LIBRARYDIR: C:\msys64\mingw64\lib
     BOOST_INCLUDEDIR: C:\msys64\mingw64\include\boost
-    CMAKE_GENERATOR: 'MSYS Makefiles'
-  - build: msvc
+  - CMAKE_GENERATOR: 'NMake Makefiles'
     platform: x86
     BOOST_ROOT: C:\Libraries\boost_1_59_0
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib32-msvc-14.0
     BOOST_INCLUDEDIR: C:\Libraries\boost_1_59_0\boost
-    CMAKE_GENERATOR: 'NMake Makefiles'
-  - build: msvc
+    QT_DIR: C:\Qt\5.8\msvc2015
+  - CMAKE_GENERATOR: 'NMake Makefiles'
     platform: x64
     BOOST_ROOT: C:\Libraries\boost_1_59_0
     BOOST_INCLUDEDIR: C:\Libraries\boost_1_59_0\boost
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
-    CMAKE_GENERATOR: 'NMake Makefiles'
-
-install:
-- git submodule init
-- git submodule update
-- set PATH=C:\Ruby%RUBY_VERSION%\bin;%BOOST_LIBRARYDIR%;%PATH%
-- gem install bundle
-- bundle install
-- bundle env
-- if "%build%"=="mingw" set PATH=%MINGW_ROOT%\bin;C:\msys64\usr\bin\;%PATH%
-- if "%build%"=="mingw" bash -lc "pacman --needed --noconfirm -S mingw-w64-%MINGW_ARCH%-boost
+    QT_DIR: C:\Qt\5.8\msvc2015_64
 
 build_script:
-- cmd: if "%build%"=="msvc" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
-- cmd: cmake -E make_directory build
-- cmd: cmake -E chdir build cmake -G "%CMAKE_GENERATOR%" -DCUKE_ENABLE_EXAMPLES=ON -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" ..
-- cmd: cmake --build build
-
-test_script:
-- cmd: set CTEST_OUTPUT_ON_FAILURE=ON
-- cmd: cmake --build build --target test
-- cmd: cmake --build build --target features
+- cmd: call appveyor.bat
 
 notifications:
 - provider: Email

--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -1,36 +1,19 @@
 project(CalcQt)
 
 set(CALCQT_HEADERS src/CalculatorWidget.h)
-set(CALCQT_SOURCES src/CalcQt.cpp src/CalculatorWidget.cpp)
-include_directories(${CUKE_INCLUDE_DIRS} src)
-
-find_package(Qt5Core QUIET)
-find_package(Qt5Widgets QUIET)
-find_package(Qt5Test QUIET)
-
-if(${Qt5Core_FOUND} AND ${Qt5Widgets_FOUND} AND ${Qt5Test_FOUND})
-    set(CMAKE_INCLUDE_CURRENT_DIR ON)
-    set(CMAKE_AUTOMOC ON)
-    set(QT_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Test)
-
-    add_library(libcalcqt src/CalculatorWidget.cpp ${CALCQT_HEADERS})
-    target_link_libraries(libcalcqt ${QT_LIBRARIES})
-    
-    add_executable(calcqt ${CALCQT_SOURCES})
-    target_link_libraries(calcqt libcalcqt ${QT_LIBRARIES})
-else()
-    find_package(Qt4 COMPONENTS QtCore QtGui QtTest)
-    if(QT4_FOUND)
-        include(${QT_USE_FILE})
-        qt4_wrap_cpp(CALCQT_HEADERS_MOC ${CALCQT_HEADERS})
-        add_library(libcalcqt src/CalculatorWidget ${CALCQT_HEADERS_MOC})
-    
-        add_executable(calcqt ${CALCQT_SOURCES} ${CALCQT_HEADERS_MOC})
-        target_link_libraries(calcqt ${QT_LIBRARIES})
-    endif()
-endif()
+include_directories(src)
 
 if(QT_LIBRARIES)
+    if(QT4_FOUND)
+        qt4_wrap_cpp(CALCQT_MOC ${CALCQT_HEADERS})
+    else()
+        qt5_wrap_cpp(CALCQT_MOC ${CALCQT_HEADERS})
+    endif()
+    add_library(libcalcqt src/CalculatorWidget.cpp ${CALCQT_MOC})
+    
+    add_executable(calcqt src/CalcQt.cpp)
+    target_link_libraries(calcqt libcalcqt ${QT_LIBRARIES})
+
     if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
         include_directories(${Boost_INCLUDE_DIRS})
         add_executable(BoostCalculatorQtSteps features/step_definitions/BoostCalculatorQtSteps)

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e #break script on non-zero exitcode from any command
 set -x #display command being executed
+
 gem install bundler
 bundle install
 


### PR DESCRIPTION
Main purpose of this PR is to setup Qt framework in CI on all 3 platforms:
- Linux via apt
- OSX via brew
- Windows using preinstalled Qt in appveyor (only mingwx64 is missing on the image)
Rework of Qt-related code in CMake files was needed to prepare for QtTest driver and ensure that CalcQt can be build under all Qt versions.
I've also done some refactoring in appveyor configuration: 
- removed not used variables
- moved  build steps to batch file
- ruby version is now hard coded instead of variable
I've also changed how travis matrix is described in config but still build targets are the same. I hope now config is more clear.

Please leave a comment how you like those changes.