### PR TITLE
GTest without filter separation

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ if(GMOCK_FOUND)
         add_executable(${TEST_NAME} ${TEST_FILE}.cpp)
         target_link_libraries(${TEST_NAME} cucumber-cpp-nomain ${CUKE_EXTRA_LIBRARIES} ${ARGN} ${CUKE_GMOCK_LIBRARIES})
         gtest_add_tests(${TEST_NAME} "" ${TEST_FILE}.cpp)
+        # Run all tests in executable at once too. This ensures that the used fixtures get tested properly too.
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     endfunction()
 
     # TODO Compile tests with the least possible code, not with the entire library

--- a/tests/utils/HookRegistrationFixture.hpp
+++ b/tests/utils/HookRegistrationFixture.hpp
@@ -118,12 +118,8 @@ protected:
 
     void SetUp() {
         CukeCommandsFixture::SetUp();
-        addStepToManager<EmptyStep>(STATIC_MATCHER);
-    }
-
-    void TearDown() {
         clearHookCallMarkers();
-        CukeCommandsFixture::TearDown();
+        addStepToManager<EmptyStep>(STATIC_MATCHER);
     }
 };
 


### PR DESCRIPTION
The `HookRegistrationFixture` didn't do all it needed to do in its SetUp method. When running all test cases in a single source file at once this caused test failures.

This PR both fixes that fixture (1a7b7b1) and runs the entire test suite at once, in addition to separated, to detect these kinds of failures in the future (04011a8).

This is the failure exposed by the different test execution (04011a8): https://travis-ci.org/muggenhor/cucumber-cpp/builds/219301662