### PR TITLE
Use HTTPS protocol instead of git for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "features/cucumber-tck"]
 	path = features/cucumber-tck
-	url = git://github.com/cucumber/cucumber-tck.git
+	url = https://github.com/cucumber/cucumber-tck.git


### PR DESCRIPTION
HTTPS is the protocol least likely to be blocked by a corporate
firewall.