### PR TITLE
Add a step-matching hook

### DIFF
--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -63,6 +63,7 @@ class HookRegistrar {
 public:
     typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
     typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
+    typedef bool(*StepMatchingHook)(const boost::cmatch&);
 
     virtual ~HookRegistrar();
 
@@ -84,6 +85,9 @@ public:
     void addAfterAllHook(const boost::shared_ptr<AfterAllHook>& afterAllHook);
     void execAfterAllHooks();
 
+    void setStepMatchingHook(StepMatchingHook hook);
+    bool execStepMatchingHook(const boost::cmatch& originalMatch);
+
 private:
     void execHooks(HookRegistrar::hook_list_type &hookList, Scenario *scenario);
 
@@ -94,6 +98,7 @@ protected:
     hook_list_type& afterStepHooks();
     hook_list_type& afterHooks();
     hook_list_type& afterAllHooks();
+    StepMatchingHook& stepMatchingHook();
 };
 
 

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -95,7 +95,6 @@ void HookRegistrar::execAfterHooks(Scenario *scenario) {
     execHooks(afterHooks(), scenario);
 }
 
-
 void HookRegistrar::execHooks(HookRegistrar::hook_list_type &hookList, Scenario *scenario) {
     for (HookRegistrar::hook_list_type::iterator hook = hookList.begin(); hook != hookList.end(); ++hook) {
         (*hook)->invokeHook(scenario, NULL);
@@ -126,6 +125,19 @@ void HookRegistrar::addAfterAllHook(const boost::shared_ptr<AfterAllHook>& after
 
 void HookRegistrar::execAfterAllHooks() {
     execHooks(afterAllHooks(), NULL);
+}
+
+void HookRegistrar::setStepMatchingHook(StepMatchingHook hook) {
+    stepMatchingHook() = hook;
+}
+
+bool HookRegistrar::execStepMatchingHook(const boost::cmatch& originalMatch) {
+    return stepMatchingHook() == nullptr || stepMatchingHook()(originalMatch);
+}
+
+HookRegistrar::StepMatchingHook& HookRegistrar::stepMatchingHook() {
+    static StepMatchingHook stepMatchingHook = nullptr;
+    return stepMatchingHook;
 }
 
 

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -132,11 +132,11 @@ void HookRegistrar::setStepMatchingHook(StepMatchingHook hook) {
 }
 
 bool HookRegistrar::execStepMatchingHook(const boost::cmatch& originalMatch) {
-    return stepMatchingHook() == nullptr || stepMatchingHook()(originalMatch);
+    return stepMatchingHook() == NULL || stepMatchingHook()(originalMatch);
 }
 
 HookRegistrar::StepMatchingHook& HookRegistrar::stepMatchingHook() {
-    static StepMatchingHook stepMatchingHook = nullptr;
+    static StepMatchingHook stepMatchingHook = NULL;
     return stepMatchingHook;
 }
 

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/utils/Regex.hpp>
+#include <cucumber-cpp/internal/hook/HookRegistrar.hpp>
 #include <boost/make_shared.hpp>
 
 namespace cucumber {
@@ -26,7 +27,8 @@ boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
 
 FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
     boost::cmatch matchResults;
-    regexMatched = boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra);
+    regexMatched = boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra)
+                   && HookRegistrar().execStepMatchingHook(matchResults);
     if (regexMatched) {
         for (boost::cmatch::size_type i = 1; i < matchResults.size(); ++i) {
             RegexSubmatch s;


### PR DESCRIPTION
The motivation behind this commit is that we get too many ambiguous
step matchings because we use (.+) as view expressions. What's a view
and what isn't is only determined at runtime (through the view
evaluators which register at runtime), so we can't describe it in a
regular expression.

With this feature, we have a say in whether or not a step should
match, by providing our own matching hook. We use regex's named
capture mechanism to activate our own matching algorithm.

Credit to @stk-ableton for the original patch.