### PR TITLE
Fix our CMake version dependency: 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 project(Cucumber-Cpp)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with [CPP].
 
 It relies on a few executables:
 
-* [cmake](https://cmake.org/download/) 2.8.12 or later.
+* [cmake](https://cmake.org/download/) 3.1 or later.
   Required to setup environment and build software
 
 It relies on a few libraries:


### PR DESCRIPTION
I.e. inside FindGMock.cmake we're using find_dependency() from the
CMakeFindDependencyMacro module. That module only got added in CMake
3.0. Furthermore we're relying on the import target Threads::Threads,
which only gets added with CMake 3.1.

So bump our requirement to what it is we really need.