### PR TITLE
Use clang format for style checking

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,32 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignEscapedNewlinesLeft: true
+AllowShortFunctionsOnASingleLine: Empty
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Attach
+ColumnLimit:     100
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ForEachMacros:   [ BOOST_FOREACH ]
+IncludeCategories: 
+  # The autodetect header should always be included last
+  - Regex:           '^<cucumber-cpp/autodetect\.hpp>$'
+    Priority:        3
+  - Regex:           '^["<]cucumber-cpp/'
+    Priority:        1
+  - Regex:           '.*'
+    Priority:        2
+IndentWidth:     4
+NamespaceIndentation: None
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 10000
+PointerAlignment: Left
+SortIncludes:    false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+Standard:        Cpp03
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     - os: linux
       compiler: gcc
       env: GMOCK_VER=1.8.0 VALGRIND_TESTS=ON
+    - os: linux
+      env: FORMAT=1
     - os: osx
       compiler: clang
       env: GMOCK_VER=1.8.0
@@ -32,6 +34,7 @@ matrix:
 addons:
   apt:
     packages:
+      - clang-format-3.8
       - libboost-thread-dev 
       - libboost-system-dev
       - libboost-regex-dev

--- a/travis.sh
+++ b/travis.sh
@@ -30,6 +30,19 @@ killXvfb () {
     fi
 }
 
+if [ -n "${FORMAT:-}" ]; then
+    # Reformat all code changed since this branch forked from the default branch
+    git fetch origin HEAD
+    if [ "${TRAVIS_PULL_REQUEST:-false}" = "false" ]; then
+        BASE_HEAD="$(git rev-parse FETCH_HEAD)"
+    else
+        BASE_HEAD="$(git merge-base FETCH_HEAD HEAD)"
+    fi
+    git clang-format-3.8 --binary=/usr/bin/clang-format-3.8 --style=file --commit="${BASE_HEAD}"
+    # Assert that all changes adhere to the asked for style
+    exec git diff --exit-code
+fi
+
 CTEST_OUTPUT_ON_FAILURE=ON
 export CTEST_OUTPUT_ON_FAILURE
 


### PR DESCRIPTION
This first adds a clang-format configuration that should match our current style as much as possible. Subsequently another Travis build gets added that uses this config to verify that all changes (when compared to the last merge from master) in a branch (including pull requests) adhere to that style. Any differences will cause that build to fail and the differences with the style, as clang-format would format it, to be shown as a highlighted unified diff.

<del>The last commit of this PR is present _only_ to demonstrate how such a failure to adhere to the style gets reported, that commit itself should _not_ be merged back into master.</del><ins>muggenhor@8b20bbeac3331c3d8ad4443d981d1e65806742fa demonstrates how such a failure looks like.</ins> That failure looks like this: https://travis-ci.org/muggenhor/cucumber-cpp/jobs/266237870

This resolves #151.