### PR TITLE
Track test coverage using coveralls service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
-os:
-  - linux
+os: linux
 sudo: required
 dist: trusty
 compiler:
@@ -12,6 +11,9 @@ env:
   - GMOCK_PATH=/usr/src/gmock #1.6.0 from ubuntu trusty repo
 matrix:
   include:
+    - os: linux
+      compiler: gcc
+      env: GMOCK_VER=1.8.0 COVERALLS_SERVICE_NAME=travis-ci
     - os: linux
       compiler: gcc
       env: GMOCK_VER=1.8.0 VALGRIND_TESTS=ON
@@ -38,9 +40,12 @@ addons:
       - qtbase5-dev
       - xvfb
 
-before_install:
+install:
   - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then brew update && brew install ninja qt5; fi
+  - if [ -n "${COVERALLS_SERVICE_NAME}" ]; then gem install coveralls-lcov; fi
+  - if [ -n "${COVERALLS_SERVICE_NAME}" ]; then wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.13.orig.tar.gz; tar xf lcov_1.13.orig.tar.gz; sudo make -C lcov-1.13/ install; fi
+# we have to build lcov on our own as version 1.10 in apt is incompatible with coveralls gem; It is not possible to install lcov from deb as it doesn't recognize installed perl package.
 
-script: ./travis.sh 
+script: ./travis.sh
 
 # default notifications: https://docs.travis-ci.com/user/notifications#Notifications

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Join the chat at https://gitter.im/cucumber/cucumber-cpp](https://badges.gitter.im/cucumber/cucumber-cpp.svg)](https://gitter.im/cucumber/cucumber-cpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Linux and OSX build status](https://travis-ci.org/cucumber/cucumber-cpp.svg)](https://travis-ci.org/cucumber/cucumber-cpp)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/5jeap3a4si9w8kka?svg=true)](https://ci.appveyor.com/project/paoloambrosio/cucumber-cpp-qqrt7)
+[![Coverage Status](https://coveralls.io/repos/github/cucumber/cucumber-cpp/badge.svg)](https://coveralls.io/github/cucumber/cucumber-cpp)
 
 Cucumber-Cpp allows Cucumber to support step definitions written in C++.
 

--- a/travis.sh
+++ b/travis.sh
@@ -20,6 +20,8 @@ cmake -E chdir build cmake \
     -G Ninja \
     -DCUKE_ENABLE_EXAMPLES=on \
     ${CMAKE_PREFIX_PATH:+"-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"} \
+    ${COVERALLS_SERVICE_NAME:+"-DCMAKE_BUILD_TYPE=Debug"} \
+    ${COVERALLS_SERVICE_NAME:+"-DCMAKE_CXX_FLAGS='--coverage'"} \
     ${VALGRIND_TESTS:+"-DVALGRIND_TESTS=${VALGRIND_TESTS}"} \
     ${GMOCK_PATH:-"-DGMOCK_VER=${GMOCK_VER}"} \
     ${GMOCK_PATH:+"-DGMOCK_SRC_DIR=${GMOCK_PATH}"} \
@@ -78,4 +80,14 @@ if [ -n "${XVFBPID:-}" ]; then
     # Stop virtual X display server
     kill $XVFBPID
     wait
+fi
+
+if [ -n "${COVERALLS_SERVICE_NAME}" ]; then
+    lcov --directory ./build --capture  --output-file coverage.info
+    lcov --remove coverage.info "/usr/*" --output-file coverage.info
+    lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/build/*" --output-file coverage.info
+    lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/tests/*" --output-file coverage.info
+    lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/include/json_spirit/*" --output-file coverage.info
+    lcov --list coverage.info
+    coveralls-lcov coverage.info
 fi

--- a/travis.sh
+++ b/travis.sh
@@ -87,6 +87,8 @@ if [ -n "${COVERALLS_SERVICE_NAME}" ]; then
     lcov --remove coverage.info "/usr/*" --output-file coverage.info
     lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/build/*" --output-file coverage.info
     lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/tests/*" --output-file coverage.info
+    lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/features/*" --output-file coverage.info
+    lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/examples/*" --output-file coverage.info
     lcov --remove coverage.info "${TRAVIS_BUILD_DIR}/include/json_spirit/*" --output-file coverage.info
     lcov --list coverage.info
     coveralls-lcov coverage.info


### PR DESCRIPTION
## Summary
Track test coverage using coveralls service
Url: https://coveralls.io
Implementation using lcov and gem coveralls-lcov


## Details
After we turned down CMake-based implementation, and I've failed to get python script from here: https://github.com/eddyxu/cpp-coveralls to work; I've based this implementation on this post: https://gronlier.fr/blog/2015/01/adding-code-coverage-to-your-c-project/ which is using lcov and ruby gem just to upload results.

## Motivation and Context

This fixes #123

## How Has This Been Tested?

No tests needed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
