### PR TITLE
Fix issue #174 -  building with boost 1.65+

### DIFF
--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -65,8 +65,13 @@ public:
     void log_entry_finish( std::ostream&) {};
 
     void entry_context_start( std::ostream&, log_level /*l*/) {}
+#if BOOST_VERSION >= 106500
+    void log_entry_context( std::ostream&, log_level /*l*/, const_string /*value*/) {}
+    void entry_context_finish( std::ostream&, log_level /*l*/ ) {}
+#else
     void log_entry_context( std::ostream&, const_string /*value*/) {}
     void entry_context_finish( std::ostream& ) {}
+#endif
 
 private:
     std::stringstream description;


### PR DESCRIPTION
## Summary

Fix  building with boost 1.65+

## Details

Boost commit https://github.com/boostorg/test/commit/fcb302b66ea09c25f0682588d22fbfdf59eac0f7#diff-bcc3185dd80b117f8fc46af27d0eba1b added additional parameter to 2 functions in log_formatter, which left our log_interceptor with 2 pure virtual functions.

## Motivation and Context

Fix  for issue #174 - building with boost 1.65+

## How Has This Been Tested?
I've built cucumber and run unit tests on my linux machine with boost 1.65.1 (which failed before this change)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
