### PR TITLE
fix conflicting "using std" declaration with "using boost::thread"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 #
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra ${CMAKE_CXX_FLAGS}")
     # TODO: A better fix should handle ld's --as-needed flag
     if(UNIX AND NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -23,8 +23,9 @@ namespace fs = boost::filesystem;
 
 static const time_duration THREAD_TEST_TIMEOUT = milliseconds(4000);
 
-MATCHER(IsConnected, std::string(negation ? "is not" : "is") +
-        " connected") { return arg.good(); }
+MATCHER(IsConnected, std::string(negation ? "is not" : "is") + " connected") {
+    return arg.good();
+}
 
 MATCHER(HasTerminated, "") {
     return !arg.joinable();
@@ -54,7 +55,7 @@ MATCHER_P(EventuallyReceives, value, "") {
 
 class MockProtocolHandler : public ProtocolHandler {
 public:
-    MOCK_CONST_METHOD1(handle, std::string(const std::string &request));
+    MOCK_CONST_METHOD1(handle, std::string(const std::string& request));
 };
 
 class SocketServerTest : public Test {

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -16,7 +16,6 @@ using namespace boost::asio::ip;
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 using namespace boost::asio::local;
 #endif
-using namespace std;
 using namespace testing;
 using boost::bind;
 using boost::thread;
@@ -24,7 +23,7 @@ namespace fs = boost::filesystem;
 
 static const time_duration THREAD_TEST_TIMEOUT = milliseconds(4000);
 
-MATCHER(IsConnected, string(negation ? "is not" : "is") +
+MATCHER(IsConnected, std::string(negation ? "is not" : "is") +
         " connected") { return arg.good(); }
 
 MATCHER(HasTerminated, "") {
@@ -55,7 +54,7 @@ MATCHER_P(EventuallyReceives, value, "") {
 
 class MockProtocolHandler : public ProtocolHandler {
 public:
-    MOCK_CONST_METHOD1(handle, string(const string &request));
+    MOCK_CONST_METHOD1(handle, std::string(const std::string &request));
 };
 
 class SocketServerTest : public Test {
@@ -134,8 +133,8 @@ TEST_F(TCPSocketServerTest, receiveAndSendsSingleLineMassages) {
     ASSERT_THAT(client, IsConnected());
 
     // when
-    client << "1" << flush << "2" << endl << flush;
-    client << "3" << endl << "4" << endl << flush;
+    client << "1" << std::flush << "2" << std::endl << std::flush;
+    client << "3" << std::endl << "4" << std::endl << std::flush;
 
     // then
     EXPECT_THAT(client, EventuallyReceives("A"));
@@ -204,7 +203,7 @@ TEST_F(UnixSocketServerTest, fullLifecycle) {
 
     // traffic flows
     stream_protocol::iostream client(socketName);
-    client << "X" << endl << flush;
+    client << "X" << std::endl << std::flush;
     EXPECT_THAT(client, EventuallyReceives("Y"));
 
     // client disconnection terminates server


### PR DESCRIPTION
## Summary

I experienced issues while building cucumber-cpp with the environment below.

Environment:
```
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.3 LTS
Release:	16.04
Codename:	xenial

gcc (Ubuntu 5.4.1-2ubuntu1~16.04) 5.4.1 20160904
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Boost 1.66.0
```

Errors:
```
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:65:29: error: template argument 1 is invalid
     boost::scoped_ptr<thread> serverThread;
                             ^
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp: In member function ‘virtual void SocketServerTest::SetUp()’:
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:69:22: error: request for member ‘reset’ in ‘((SocketServerTest*)this)->SocketServerTest::serverThread’, which is of non-class type ‘int’
         serverThread.reset(new thread(&SocketServer::acceptOnce, server));
                      ^
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:69:32: error: expected type-specifier before ‘thread’
         serverThread.reset(new thread(&SocketServer::acceptOnce, server));
                                ^
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:68:23: error: unused variable ‘server’ [-Werror=unused-variable]
         SocketServer* server = createListeningServer();
                       ^
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp: In member function ‘virtual void SocketServerTest::TearDown()’:
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:74:25: error: base operand of ‘->’ is not a pointer
             serverThread->timed_join(THREAD_TEST_TIMEOUT);
                         ^
/home/matt/.conan/data/cucumber-cpp/0.4/murex/testing/build/232742180d6b48ffcaf9de5114f5a9b14f6df7e4/cucumber-cpp-0.4/tests/integration/WireServerTest.cpp:75:26: error: request for member ‘reset’ in ‘((SocketServerTest*)this)->SocketServerTest::serverThread’, which is of non-class type ‘int’
             serverThread.reset();
                          ^
```

`using std;` creates a conflict with `using boost::thread;` because `std` has also a class [thread](http://en.cppreference.com/w/cpp/thread/thread) that must have been previously included by `boost/thread.hpp`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
