### PR TITLE
[cmake] adding a target install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,13 @@ endif()
 #
 # Cucumber-Cpp
 #
+set (CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}")
+set (CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
+set (CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
 
 set(CUKE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+install(DIRECTORY ${CUKE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 add_subdirectory(3rdparty/json_spirit)
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,13 +251,8 @@ endif()
 #
 # Cucumber-Cpp
 #
-set (CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}")
-set (CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
-set (CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
 
 set(CUKE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
-install(DIRECTORY ${CUKE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
 add_subdirectory(3rdparty/json_spirit)
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,16 @@ git submodule update
 cmake -E make_directory build
 
 # Generate Makefiles
-cmake -E chdir build cmake -DCUKE_ENABLE_EXAMPLES=on ..
+cmake -E chdir build cmake -DCUKE_ENABLE_EXAMPLES=on -DCMAKE_INSTALL_PREFIX=${prefix} ..
 
 # Build cucumber-cpp and tests
 cmake --build build
 
 # Run unit tests
 cmake --build build --target test
+
+# Run install
+cmake --build build --target install
 
 # Check implementation against common cucumber test suite
 cmake --build build --target features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,7 @@ test_script:
 - set CTEST_OUTPUT_ON_FAILURE=ON
 - cmake --build build --target test
 - cmake --build build --target features
+- cmake --build build --target install
 
 after_test:
 - for /r %%v in (TEST-*.xml) do curl -s -F "file=@%%v;filename=%%~nxv" https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,11 +104,25 @@ target_link_libraries(cucumber-cpp
         Boost::program_options
 )
 
-install(TARGETS cucumber-cpp-nomain
+include(GNUInstallDirs)
+install(DIRECTORY ${CUKE_INCLUDE_DIR}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/cucumber-cpp/internal/CukeExport.hpp"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cucumber-cpp/internal"
+)
+install(
+    TARGETS
+        cucumber-cpp-nomain
+        cucumber-cpp
+    EXPORT   CucumberCpp
     ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(TARGETS cucumber-cpp
-    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(
+    EXPORT      CucumberCpp
+    NAMESPACE   CucumberCpp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+    FILE        CucumberCppConfig.cmake
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,8 +71,9 @@ foreach(TARGET
 )
     target_include_directories(${TARGET}
         PUBLIC
-            ${CMAKE_CURRENT_BINARY_DIR}
-            ${CMAKE_SOURCE_DIR}/include
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
     )
     target_link_libraries(${TARGET}
         PUBLIC
@@ -102,3 +103,12 @@ target_link_libraries(cucumber-cpp
     PRIVATE
         Boost::program_options
 )
+
+install(TARGETS cucumber-cpp-nomain
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS cucumber-cpp
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/travis.sh
+++ b/travis.sh
@@ -58,6 +58,7 @@ cmake -E chdir build cmake \
     -G Ninja \
     -DCUKE_ENABLE_EXAMPLES=on \
     -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_PREFIX=${HOME}/.local \
     ${CMAKE_PREFIX_PATH:+"-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"} \
     ${COVERALLS_SERVICE_NAME:+"-DCMAKE_BUILD_TYPE=Debug"} \
     ${COVERALLS_SERVICE_NAME:+"-DCMAKE_CXX_FLAGS='--coverage'"} \
@@ -109,3 +110,5 @@ if [ -f "${TEST}" ]; then
 fi
 
 killXvfb
+
+cmake --build build --target install


### PR DESCRIPTION
I propose to add a target `install` to CMakeLists.txt

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.