### PR TITLE
fix OSX build failing on warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 #
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
     # TODO: A better fix should handle ld's --as-needed flag
     if(UNIX AND NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 #
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra ${CMAKE_CXX_FLAGS}")
     # TODO: A better fix should handle ld's --as-needed flag
     if(UNIX AND NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")

--- a/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
+++ b/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
@@ -36,12 +36,16 @@ GIVEN("^I just turned on the calculator$") {
     cucumber::ScenarioScope<CalculatorCtx> ctx;
     ctx->calculator.move(0, 0);
     ctx->calculator.show();
-    bool _; //just to suppress warning
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-result"
 #if QT_VERSION >= 0x050000
-    _ = QTest::qWaitForWindowExposed(&ctx->calculator);
+    QTest::qWaitForWindowExposed(&ctx->calculator);
 #else
-    _ = QTest::qWaitForWindowShown(&ctx->calculator);
+    QTest::qWaitForWindowShown(&ctx->calculator);
 #endif
+#pragma clang diagnostic pop
+
     QTest::qWait(millisecondsToWait());
 }
 

--- a/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
+++ b/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
@@ -36,7 +36,7 @@ GIVEN("^I just turned on the calculator$") {
     cucumber::ScenarioScope<CalculatorCtx> ctx;
     ctx->calculator.move(0, 0);
     ctx->calculator.show();
-#ifdef __clang__  
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
 #endif
@@ -45,7 +45,7 @@ GIVEN("^I just turned on the calculator$") {
 #else
     QTest::qWaitForWindowShown(&ctx->calculator);
 #endif
-#ifdef __clang__  
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 

--- a/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
+++ b/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
@@ -36,15 +36,18 @@ GIVEN("^I just turned on the calculator$") {
     cucumber::ScenarioScope<CalculatorCtx> ctx;
     ctx->calculator.move(0, 0);
     ctx->calculator.show();
-
+#ifdef __clang__  
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
+#endif
 #if QT_VERSION >= 0x050000
     QTest::qWaitForWindowExposed(&ctx->calculator);
 #else
     QTest::qWaitForWindowShown(&ctx->calculator);
 #endif
+#ifdef __clang__  
 #pragma clang diagnostic pop
+#endif
 
     QTest::qWait(millisecondsToWait());
 }

--- a/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
+++ b/examples/CalcQt/features/step_definitions/CalculatorQtSteps.cpp
@@ -36,10 +36,11 @@ GIVEN("^I just turned on the calculator$") {
     cucumber::ScenarioScope<CalculatorCtx> ctx;
     ctx->calculator.move(0, 0);
     ctx->calculator.show();
+    bool _; //just to suppress warning
 #if QT_VERSION >= 0x050000
-    QTest::qWaitForWindowExposed(&ctx->calculator);
+    _ = QTest::qWaitForWindowExposed(&ctx->calculator);
 #else
-    QTest::qWaitForWindowShown(&ctx->calculator);
+    _ = QTest::qWaitForWindowShown(&ctx->calculator);
 #endif
     QTest::qWait(millisecondsToWait());
 }


### PR DESCRIPTION
## Summary

fix OSX build by removing -werror

## Details 

## Motivation and Context

OSX builds started failing becouse of harmless warning treated as error

## How Has This Been Tested?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
