### PR TITLE
fix qt building

### DIFF
--- a/examples/Calc/CMakeLists.txt
+++ b/examples/Calc/CMakeLists.txt
@@ -21,7 +21,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     target_link_libraries(BoostCalculatorSteps Calc ${CUKE_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 endif()
 
-if(Qt5TEST_FOUND)
+if(Qt5Test_FOUND)
     add_executable(QtTestCalculatorSteps features/step_definitions/QtTestCalculatorSteps)
     target_link_libraries(QtTestCalculatorSteps Calc Qt5::Test ${CUKE_LIBRARIES})
 endif()

--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -9,7 +9,7 @@ if(QT_LIBRARIES)
     add_executable(calcqt src/CalcQt.cpp)
     target_link_libraries(calcqt libcalcqt ${QT_LIBRARIES})
 
-    if(Qt5TEST_FOUND)
+    if(Qt5Test_FOUND)
         add_executable(QtTestCalculatorQtSteps features/step_definitions/QtTestCalculatorQtSteps)
         target_link_libraries(QtTestCalculatorQtSteps PRIVATE libcalcqt ${QT_LIBRARIES} ${CUKE_LIBRARIES})
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     list(APPEND CUKE_SOURCES drivers/BoostDriver.cpp)
 endif()
 
-if(Qt5TEST_FOUND)
+if(Qt5Test_FOUND)
     qt5_wrap_cpp(MOC_FILE ../include/cucumber-cpp/internal/drivers/QtTestDriver.hpp)
     list(APPEND CUKE_SOURCES ${MOC_FILE})
     list(APPEND CUKE_SOURCES drivers/QtTestDriver.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     cuke_add_driver_test(integration/drivers/BoostDriverTest ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 endif()
 
-if(Qt5TEST_FOUND)
+if(Qt5Test_FOUND)
     cuke_add_driver_test(integration/drivers/QtTestDriverTest ${QT_LIBRARIES})
 endif()
 


### PR DESCRIPTION
## Summary

Fix building QtTest parts of cucumber 

## Details

Some parts of QtTest were not building because of mistyped variable

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

QtTest examples are now building correctly

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
