### PR TITLE
Fixing Visual Studio 2013 error: no appropriate default constructor available

### DIFF
--- a/tests/unit/StepManagerTest.cpp
+++ b/tests/unit/StepManagerTest.cpp
@@ -12,9 +12,11 @@ using namespace cucumber::internal;
 
 class StepManagerTest : public ::testing::Test {
 public:
+    virtual ~StepManagerTest() {}
     typedef StepManagerTestDouble StepManager;
 
 protected:
+    StepManagerTest() {}
     const static char *a_matcher;
     const static char *another_matcher;
     const static char *no_match;


### PR DESCRIPTION
## Summary

Code fix to remove a `no appropriate default constructor available compilation` error with Visual Studio 2013.

## Details

I was getting the below error:

```
\tests\unit\StepManagerTest.cpp(78): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(86): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(94): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(103): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(110): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(121): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
\tests\unit\StepManagerTest.cpp(128): error C2512: 'StepManagerTest' : no appropriate default constructor available [tests\StepManagerTest.vcxproj]
```

## Motivation and Context

This fix is required to remove the solve the above error.
It allows the project to be built with the tests enabled with Visual Studio 2013.

## How Has This Been Tested?

The patched project was successfully built with all tests passing on our internal CI with Visual Studio 2013/2017 on Windows and GCC 4.9, 6.3 and 7.3 on Linux.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
