### PR TITLE
[vs2017] warning C4265: class has virtual functions, but destructor is not virtual

### DIFF
--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -22,6 +22,11 @@ public:
 
 class CUCUMBER_CPP_EXPORT Hook {
 public:
+    // [Visual Studio] silence false positive "warning C4265: class has virtual
+    // functions, but destructor is not virtual" requiring virtual destructors
+    // for every class that has virtual functions.
+    virtual ~Hook() {}
+
     void setTags(const std::string &csvTagNotation);
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
     virtual void skipHook();

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -22,9 +22,6 @@ public:
 
 class CUCUMBER_CPP_EXPORT Hook {
 public:
-    // [Visual Studio] silence false positive "warning C4265: class has virtual
-    // functions, but destructor is not virtual" requiring virtual destructors
-    // for every class that has virtual functions.
     virtual ~Hook() {}
 
     void setTags(const std::string &csvTagNotation);

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -102,6 +102,12 @@ public:
 class CUCUMBER_CPP_EXPORT StepInfo : public boost::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
+
+    // [Visual Studio] silence false positive "warning C4265: class has virtual
+    // functions, but destructor is not virtual" requiring virtual destructors
+    // for every class that has virtual functions.
+    virtual ~StepInfo() {}
+
     SingleStepMatch matches(const std::string &stepDescription) const;
     virtual InvokeResult invokeStep(const InvokeArgs * pArgs) const = 0;
 
@@ -115,6 +121,11 @@ private:
 
 class CUCUMBER_CPP_EXPORT BasicStep {
 public:
+    // [Visual Studio] silence false positive "warning C4265: class has virtual
+    // functions, but destructor is not virtual" requiring virtual destructors
+    // for every class that has virtual functions.
+    virtual ~BasicStep() {}
+
     InvokeResult invoke(const InvokeArgs *pArgs);
 
 protected:

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -103,9 +103,6 @@ class CUCUMBER_CPP_EXPORT StepInfo : public boost::enable_shared_from_this<StepI
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
 
-    // [Visual Studio] silence false positive "warning C4265: class has virtual
-    // functions, but destructor is not virtual" requiring virtual destructors
-    // for every class that has virtual functions.
     virtual ~StepInfo() {}
 
     SingleStepMatch matches(const std::string &stepDescription) const;
@@ -121,9 +118,6 @@ private:
 
 class CUCUMBER_CPP_EXPORT BasicStep {
 public:
-    // [Visual Studio] silence false positive "warning C4265: class has virtual
-    // functions, but destructor is not virtual" requiring virtual destructors
-    // for every class that has virtual functions.
     virtual ~BasicStep() {}
 
     InvokeResult invoke(const InvokeArgs *pArgs);


### PR DESCRIPTION
VS2017 triggers the following warnings:
```
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\step\stepmanager.hpp(114): warning C4265: 'cucumber::internal::StepInfo': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\step\stepmanager.hpp(163): warning C4265: 'cucumber::internal::BasicStep': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(38): warning C4265: 'cucumber::internal::Hook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(40): warning C4265: 'cucumber::internal::BeforeHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(48): warning C4265: 'cucumber::internal::AroundStepHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(50): warning C4265: 'cucumber::internal::AfterStepHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(52): warning C4265: 'cucumber::internal::AfterHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(57): warning C4265: 'cucumber::internal::UnconditionalHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(59): warning C4265: 'cucumber::internal::BeforeAllHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\hook\hookregistrar.hpp(61): warning C4265: 'cucumber::internal::AfterAllHook': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\drivers\gtestdriver.hpp(22): warning C4265: 'cucumber::internal::GTestStep': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager0': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager1': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager2': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager3': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager4': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager5': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager6': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager7': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
warning C4265: 'CukeObjectDeliveryManager8': class has virtual functions, but destructor is not virtual
         instances of this class may not be destructed correctly
cucumber-cpp\6390bee9b32\include\cucumber-cpp\internal\step\stepmanager.hpp(172): warning C4265: 'cucumber::internal::StepInvoker<T>': class has virtual functions, but destructor is not virtual
```