### PR TITLE
[boost] fix link issue with boost_system when statically linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
         "IMPORTED_LOCATION" "${Boost_SYSTEM_LIBRARY}"
         "INTERFACE_LINK_LIBRARIES" "Boost::boost"
     )
+    if(Boost_USE_STATIC_LIBS)
+        set_target_properties(Boost::system PROPERTIES
+            "COMPILE_DEFINITIONS" BOOST_ERROR_CODE_HEADER_ONLY=1
+        )
+    endif()
 endif()
 if(Boost_FILESYSTEM_LIBRARY AND NOT TARGET Boost::filesystem)
     add_library(Boost::filesystem ${LIBRARY_TYPE} IMPORTED)


### PR DESCRIPTION
On Windows, symbols related to boost::system are missing when using a static version of boost-system.
BOOST_ERROR_CODE_HEADER_ONLY must be defined because of this piece of code in [boost/system/error_code.hpp](https://www.boost.org/doc/libs/1_67_0/boost/system/error_code.hpp).
```c++
#ifdef BOOST_ERROR_CODE_HEADER_ONLY
    inline const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
    inline const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
#else
    BOOST_SYSTEM_DECL const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
    BOOST_SYSTEM_DECL const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
#endif
```
If BOOST_ERROR_CODE_HEADER_ONLY is not defined, symbols of _system_category()_ and _generic_category()_ are prepended with `__imp_` (due to BOOST_SYSTEM_DECL -> `__declspec(dllimport)`) and not found when linking against libcucumber-cpp.lib