### PR TITLE
[cmake] add support for Conan, a C++ package manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,17 @@ option(VALGRIND_TESTS           "Run tests within Valgrind" OFF)
 set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise downloaded)")
 set(GMOCK_VER "1.7.0" CACHE STRING "Google Mock framework version to be used")
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+#
+# Conan support
+#
+
+if (EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    message(STATUS "conan_basic_setup()")
+    conan_basic_setup()
+endif()
+
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules;${CMAKE_MODULE_PATH}")
 
 #
 # Generic Compiler Flags


### PR DESCRIPTION
What do you think about including support for [Conan](https://conan.io/) ?
In my opinion, it makes the build of cucumber-cpp easier.

The user should only have to add `conanfile.txt` at the root of the project with for instance the content below:
```
[requires]
boost/1.66.0@conan/stable
gtest/1.8.0@bincrafters/stable

[generators]
cmake

[options]
Boost:skip_lib_rename=True
```

