### PR TITLE
Fix #203: QtTestCalculatorQtSteps is not generated because of a typo in CMakeLists.txt

### DIFF
--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -15,10 +15,8 @@ if(TARGET Qt::Core AND TARGET Qt::Gui AND TARGET Qt::Widgets AND TARGET Qt::Test
     add_executable(calcqt src/CalcQt.cpp)
     target_link_libraries(calcqt PRIVATE libcalcqt Qt::Widgets)
 
-    if(Qt::Test)
-        add_executable(QtTestCalculatorQtSteps features/step_definitions/QtTestCalculatorQtSteps)
-        target_link_libraries(QtTestCalculatorQtSteps PRIVATE libcalcqt Qt::Test cucumber-cpp)
-    endif()
+    add_executable(QtTestCalculatorQtSteps features/step_definitions/QtTestCalculatorQtSteps)
+    target_link_libraries(QtTestCalculatorQtSteps PRIVATE libcalcqt Qt::Test cucumber-cpp)
 
     if(TARGET Boost::unit_test_framework)
         add_executable(BoostCalculatorQtSteps features/step_definitions/BoostCalculatorQtSteps.cpp)

--- a/travis.sh
+++ b/travis.sh
@@ -70,7 +70,9 @@ cmake --build build
 cmake --build build --target test
 cmake --build build --target features
 
-startXvfb # Start virtual X display server
+#
+# Execute Calc examples
+#
 
 for TEST in \
     build/examples/Calc/GTestCalculatorSteps \
@@ -78,20 +80,24 @@ for TEST in \
     build/examples/Calc/BoostCalculatorSteps \
     build/examples/Calc/FuncArgsCalculatorSteps \
 ; do
-    if [ -f "${TEST}" ]; then
-        "${TEST}" > /dev/null &
-        sleep 1
-        cucumber examples/Calc
-        wait %
-    fi
+    "${TEST}" > /dev/null &
+    sleep 1
+    cucumber examples/Calc
+    wait %
 done
+
+#
+# Execute QtCalc examples
+#
+
+startXvfb # Start virtual X display server
 
 for TEST in \
     build/examples/CalcQt/GTestCalculatorQtSteps \
     build/examples/CalcQt/QtTestCalculatorQtSteps \
     build/examples/CalcQt/BoostCalculatorQtSteps \
 ; do
-    if [ -f "${TEST}" -a -n "${DISPLAY:-}" ]; then
+    if [ -n "${DISPLAY:-}" ]; then
         "${TEST}" 2> /dev/null &
         sleep 1
         cucumber examples/CalcQt
@@ -99,16 +105,18 @@ for TEST in \
     fi
 done
 
-# Test unix sockets
+killXvfb
+
+#
+# Execute feature showcase on Unix socket
+#
+
 SOCK=cucumber.wire.sock
 TEST=build/examples/FeatureShowcase/FeatureShowcaseSteps
-if [ -f "${TEST}" ]; then
-    echo "unix: ${SOCK}" > examples/FeatureShowcase/features/step_definitions/cucumber.wire
-    "${TEST}" --unix "${SOCK}" > /dev/null &
-    cucumber examples/FeatureShowcase
-    wait %
-fi
+echo "unix: ${SOCK}" > examples/FeatureShowcase/features/step_definitions/cucumber.wire
+"${TEST}" --unix "${SOCK}" > /dev/null &
+cucumber examples/FeatureShowcase
+wait %
 
-killXvfb
 
 cmake --build build --target install


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix a typo that prevents `build/examples/CalcQt/QtTestCalculatorQtSteps` from being generated.  
It is, however, leaking memory. See #212 

## How Has This Been Tested?

Clone and build with examples, look for `build/examples/CalcQt/QtTestCalculatorQtSteps`. It is missing. Apply this change, rebuild, it appears.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
