### PR TITLE
Fix #214: Better integration with CMake 3.13 (CMP0077)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.3")
     cmake_policy(SET CMP0063 NEW)
 endif()
 
+if (NOT CMAKE_VERSION VERSION_LESS "3.13")
+    # CMP0077: option() honors normal variables
+    # https://cmake.org/cmake/help/latest/policy/CMP0077.html
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
 project(Cucumber-Cpp)
 
 option(BUILD_SHARED_LIBS        "Generate shared libraries" OFF)


### PR DESCRIPTION
## Summary

This allows to use regular variables to configure cucumber-cpp when it's connected as a sub-directory (without having to redefine options or setting cache entries).

[CMP0077: option() honors normal variables](https://cmake.org/cmake/help/latest/policy/CMP0077.html)

## Example

```
set (CUKE_USE_STATIC_GTEST ON)
add_subdirectory (
    ${cucumber_cpp_SOURCE_DIR}
    ${cucumber_cpp_BINARY_DIR}
)
```

Fixes: #214 