### PR TITLE
Force ffi version that works with Ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ group :test do
   gem 'cucumber', "=2.0.0"
   gem 'aruba', "=0.8.0"
   gem 'rspec', "=3.4.0"
+  gem 'childprocess', "=0.5.9"
+  gem 'ffi', "=1.9.25"
 end
 


### PR DESCRIPTION
Closes #217.
