### PR TITLE
Fix regression on optional regex submatches

### DIFF
--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -37,6 +37,8 @@ FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string 
             if (i->matched) {
                 RegexSubmatch s = {*i, i->first - expression.begin()};
                 submatches.push_back(s);
+            } else {
+                submatches.push_back(RegexSubmatch());
             }
         }
     }

--- a/tests/unit/RegexTest.cpp
+++ b/tests/unit/RegexTest.cpp
@@ -46,6 +46,22 @@ TEST(RegexTest, matchesRegexWithSubmatches) {
     EXPECT_EQ("69", match->getSubmatches()[1].value);
 }
 
+TEST(RegexTest, matchesRegexWithOptionalSubmatches) {
+    Regex sum("^(\\d+)\\+(\\d+)(?:\\+(\\d+))?=(\\d+)$");
+
+    shared_ptr<RegexMatch> match(sum.find("1+2+3=6"));
+    EXPECT_TRUE(match->matches());
+    ASSERT_EQ(4, match->getSubmatches().size());
+
+    match = shared_ptr<RegexMatch>(sum.find("42+27=69"));
+    EXPECT_TRUE(match->matches());
+    ASSERT_EQ(4, match->getSubmatches().size());
+    EXPECT_EQ("42", match->getSubmatches()[0].value);
+    EXPECT_EQ("27", match->getSubmatches()[1].value);
+    EXPECT_EQ("", match->getSubmatches()[2].value);
+    EXPECT_EQ("69", match->getSubmatches()[3].value);
+}
+
 TEST(RegexTest, findAllDoesNotMatchIfNoTokens) {
     Regex sum("([^,]+)(?:,|$)");
     shared_ptr<RegexMatch> match(sum.findAll(""));


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fixes a regression that was introduced in commit a7ff906 (_Regex: use iterators for match results_).

## Details

Until commit a7ff906, the vector returned by `RegexMatch::getSubmatches()` contained an empty string item for each optional submatch that didn't match. Commit a7ff906 broke that behavior by skipping any submatch that didn't match.

## How Has This Been Tested?

I added a test (`matchesRegexWithOptionalSubmatches`) to `tests/unit/RegexTest.cpp`.
I cherry-picked this test on top of 4dec371ca9a379cf762b32e94949d2bd39f2d77e (the parent commit of a7ff906ab379a055f4d9d06e1efdf00fc9434e72) and verified that it was passing. I then verified that this test doesn't pass on top of the latest `master` without the corresponding change in `src/Regex.cpp`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
