### PR TITLE
Add ability to send embeddings through the wire protocol

### DIFF
--- a/examples/Calc/features/step_definitions/CalculatorSteps.cpp
+++ b/examples/Calc/features/step_definitions/CalculatorSteps.cpp
@@ -25,12 +25,19 @@ WHEN("^I press add") {
 WHEN("^I press divide") {
     ScenarioScope<CalcCtx> context;
 
+    embed("Some text", "text/plain", "Embedded text");
+
     context->result = context->calc.divide();
 }
 
 THEN("^the result should be (.*) on the screen$") {
     REGEX_PARAM(double, expected);
     ScenarioScope<CalcCtx> context;
+
+    embed("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5E"
+          "rkJggg==",
+          "image/png;base64",
+          "Embedded image");
 
     EXPECT_EQ(expected, context->result);
 }

--- a/include/cucumber-cpp/internal/CukeEngine.hpp
+++ b/include/cucumber-cpp/internal/CukeEngine.hpp
@@ -8,6 +8,7 @@
 #include <boost/multi_array.hpp>
 
 #include <cucumber-cpp/internal/CukeExport.hpp>
+#include <cucumber-cpp/internal/step/StepManager.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -39,23 +40,6 @@ public:
     virtual ~InvokeException() {}
 };
 
-class CUCUMBER_CPP_EXPORT InvokeFailureException : public InvokeException {
-private:
-    const std::string exceptionType;
-
-public:
-    InvokeFailureException(const std::string & message, const std::string & exceptionType);
-    InvokeFailureException(const InvokeFailureException &rhs);
-
-    const std::string getExceptionType() const;
-};
-
-class CUCUMBER_CPP_EXPORT PendingStepException : public InvokeException {
-public:
-    PendingStepException(const std::string & message);
-    PendingStepException(const PendingStepException &rhs);
-};
-
 /**
  * The entry point to Cucumber.
  *
@@ -84,9 +68,13 @@ public:
     /**
      * Invokes a step passing arguments to it.
      *
-     * @throws InvokeException if the test fails or it is pending
+     * @throws InvokeException if something unexpected happen during the execution of the step
+     * (failing or pending steps are expected, they will not trigger an exception).
      */
-    virtual void invokeStep(const std::string & id, const invoke_args_type & args, const invoke_table_type & tableArg) = 0;
+    virtual InvokeResult invokeStep(const std::string& id,
+                                    const invoke_args_type& args,
+                                    const invoke_table_type& tableArg)
+        = 0;
 
     /**
      * Ends a scenario.

--- a/include/cucumber-cpp/internal/CukeEngineImpl.hpp
+++ b/include/cucumber-cpp/internal/CukeEngineImpl.hpp
@@ -21,7 +21,9 @@ private:
 public:
     std::vector<StepMatch> stepMatches(const std::string & name) const;
     void beginScenario(const tags_type & tags);
-    void invokeStep(const std::string & id, const invoke_args_type & args, const invoke_table_type & tableArg);
+    InvokeResult invokeStep(const std::string& id,
+                            const invoke_args_type& args,
+                            const invoke_table_type& tableArg);
     void endScenario(const tags_type & tags);
     std::string snippetText(const std::string & keyword, const std::string & name, const std::string & multilineArgClass) const;
 };

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -26,19 +26,30 @@ public:
 };
 
 class CUCUMBER_CPP_EXPORT SuccessResponse : public WireResponse {
+private:
+    const std::vector<Embedding> embeddings;
+
 public:
+    SuccessResponse(const std::vector<Embedding>& embeddings = std::vector<Embedding>());
+
+    const std::vector<Embedding>& getEmbeddings() const;
+
     void accept(WireResponseVisitor& visitor) const;
 };
 
 class CUCUMBER_CPP_EXPORT FailureResponse : public WireResponse {
 private:
     const std::string message, exceptionType;
+    const std::vector<Embedding> embeddings;
 
 public:
-    FailureResponse(const std::string & message = "", const std::string & exceptionType = "");
+    FailureResponse(const std::string& message = "",
+                    const std::string& exceptionType = "",
+                    const std::vector<Embedding>& embeddings = std::vector<Embedding>());
 
     const std::string getMessage() const;
     const std::string getExceptionType() const;
+    const std::vector<Embedding>& getEmbeddings() const;
 
     void accept(WireResponseVisitor& visitor) const;
 };

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -82,10 +82,11 @@ public:
     std::string src, mime, label;
 
     Embedding(const std::string& src, const std::string& mime, const std::string& label);
-    Embedding(const Embedding& other);
-
-    Embedding& operator=(const Embedding& rhs);
 };
+
+bool operator==(const Embedding& lhs, const Embedding& rhs);
+
+std::ostream& operator<<(std::ostream& os, const Embedding& e);
 
 class CUCUMBER_CPP_EXPORT InvokeResult {
 private:
@@ -93,11 +94,9 @@ private:
     std::string description;
     std::vector<Embedding> embeddings;
 
-    InvokeResult(const InvokeResultType type, const std::string& description);
-
     InvokeResult(const InvokeResultType type,
                  const std::string& description,
-                 const std::vector<Embedding>& embeddings);
+                 const std::vector<Embedding>& embeddings = std::vector<Embedding>());
 
 public:
     InvokeResult();

--- a/src/CukeEngine.cpp
+++ b/src/CukeEngine.cpp
@@ -16,29 +16,6 @@ const std::string InvokeException::getMessage() const {
 }
 
 
-InvokeFailureException::InvokeFailureException(const std::string & message, const std::string & exceptionType) :
-        InvokeException(message),
-        exceptionType(exceptionType) {
-}
-
-InvokeFailureException::InvokeFailureException(const InvokeFailureException &rhs) :
-    InvokeException(rhs),
-    exceptionType(rhs.exceptionType) {
-}
-
-const std::string InvokeFailureException::getExceptionType() const {
-    return exceptionType;
-}
-
-
-PendingStepException::PendingStepException(const std::string & message) :
-        InvokeException(message) {
-}
-
-PendingStepException::PendingStepException(const PendingStepException &rhs) :
-    InvokeException(rhs) {
-}
-
 CukeEngine::CukeEngine() {}
 
 CukeEngine::~CukeEngine() {}

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -44,7 +44,9 @@ void CukeEngineImpl::beginScenario(const tags_type & tags) {
     cukeCommands.beginScenario(tags);
 }
 
-void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type & args, const invoke_table_type & tableArg) {
+InvokeResult CukeEngineImpl::invokeStep(const std::string& id,
+                                        const invoke_args_type& args,
+                                        const invoke_table_type& tableArg) {
     typedef invoke_table_type::index table_index;
 
     InvokeArgs commandArgs;
@@ -71,19 +73,10 @@ void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type &
         throw InvokeException("Unable to decode arguments");
     }
 
-    InvokeResult commandResult;
     try {
-        commandResult = cukeCommands.invoke(convertId(id), &commandArgs);
+        return cukeCommands.invoke(convertId(id), &commandArgs);
     } catch (...) {
         throw InvokeException("Uncatched exception");
-    }
-    switch (commandResult.getType()) {
-    case SUCCESS:
-        return;
-    case FAILURE:
-        throw InvokeFailureException(commandResult.getDescription(), "");
-    case PENDING:
-        throw PendingStepException(commandResult.getDescription());
     }
 }
 

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -53,19 +53,14 @@ Table & InvokeArgs::getVariableTableArg() {
 Embedding::Embedding(const std::string& src, const std::string& mime, const std::string& label)
     : src(src), mime(mime), label(label) {}
 
-Embedding::Embedding(const Embedding& other)
-    : src(other.src), mime(other.mime), label(other.label) {}
-
-Embedding& Embedding::operator=(const Embedding& rhs) {
-    src = rhs.src;
-    mime = rhs.mime;
-    label = rhs.label;
-
-    return *this;
+bool operator==(const Embedding& lhs, const Embedding& rhs) {
+    return lhs.src == rhs.src && lhs.mime == rhs.mime && lhs.label == rhs.label;
 }
 
-InvokeResult::InvokeResult(const InvokeResultType type, const std::string& description)
-    : type(type), description(description), embeddings() {}
+std::ostream& operator<<(std::ostream& os, const Embedding& e) {
+    return os << "{src: \"" << e.src << "\"; mime_type: \"" << e.mime << "\"; label: \"" << e.label
+              << "\"}";
+}
 
 InvokeResult::InvokeResult(const InvokeResultType type,
                            const std::string& description,

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -23,15 +23,21 @@ namespace internal {
  * Responses
  */
 
+SuccessResponse::SuccessResponse(const std::vector<Embedding>& embeddings)
+    : embeddings(embeddings) {}
+
+const std::vector<Embedding>& SuccessResponse::getEmbeddings() const {
+    return embeddings;
+}
 
 void SuccessResponse::accept(WireResponseVisitor& visitor) const {
     visitor.visit(*this);
 }
 
-FailureResponse::FailureResponse(const std::string & message, const std::string & exceptionType) :
-    message(message),
-    exceptionType(exceptionType) {
-}
+FailureResponse::FailureResponse(const std::string& message,
+                                 const std::string& exceptionType,
+                                 const std::vector<Embedding>& embeddings)
+    : message(message), exceptionType(exceptionType), embeddings(embeddings) {}
 
 const std::string FailureResponse::getMessage() const {
     return message;
@@ -39,6 +45,10 @@ const std::string FailureResponse::getMessage() const {
 
 const std::string FailureResponse::getExceptionType() const {
     return exceptionType;
+}
+
+const std::vector<Embedding>& FailureResponse::getEmbeddings() const {
+    return embeddings;
 }
 
 void FailureResponse::accept(WireResponseVisitor& visitor) const {
@@ -226,6 +236,22 @@ namespace {
             jsonOutput.push_back(*detail);
         }
 
+        mArray convertEmbeddings(const std::vector<Embedding>& embeddings) {
+            mArray embedList;
+
+            for (std::vector<Embedding>::const_iterator it = embeddings.begin();
+                 it < embeddings.end();
+                 ++it) {
+                mObject embedObject;
+                embedObject["src"] = it->src;
+                embedObject["mime_type"] = it->mime;
+                embedObject["label"] = it->label;
+                embedList.push_back(embedObject);
+            }
+
+            return embedList;
+        }
+
     public:
         std::string encode(const WireResponse& response) {
             jsonOutput.clear();
@@ -234,8 +260,19 @@ namespace {
             return write_string(v, false);
         }
 
-        void visit(const SuccessResponse& /*response*/) {
-            success();
+        void visit(const SuccessResponse& response) {
+            mObject detailObject;
+
+            if (!response.getEmbeddings().empty()) {
+                detailObject["embeddings"] = convertEmbeddings(response.getEmbeddings());
+            }
+
+            if (detailObject.empty()) {
+                success();
+            } else {
+                const mValue detail(detailObject);
+                success(&detail);
+            }
         }
 
         void visit(const FailureResponse& response) {
@@ -245,6 +282,9 @@ namespace {
             }
             if (!response.getExceptionType().empty()) {
                 detailObject["exception"] = response.getExceptionType();
+            }
+            if (!response.getEmbeddings().empty()) {
+                detailObject["embeddings"] = convertEmbeddings(response.getEmbeddings());
             }
             if (detailObject.empty()) {
                 fail();

--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -49,13 +49,14 @@ InvokeCommand::InvokeCommand(const std::string & stepId,
 
 boost::shared_ptr<WireResponse> InvokeCommand::run(CukeEngine& engine) const {
     try {
-        InvokeResult commandResult = engine.invokeStep(stepId, args, tableArg);
+        const InvokeResult commandResult = engine.invokeStep(stepId, args, tableArg);
 
         switch (commandResult.getType()) {
         case SUCCESS:
-            return boost::make_shared<SuccessResponse>();
+            return boost::make_shared<SuccessResponse>(commandResult.getEmbeddings());
         case FAILURE:
-            return boost::make_shared<FailureResponse>(commandResult.getDescription(), "");
+            return boost::make_shared<FailureResponse>(
+                commandResult.getDescription(), "", commandResult.getEmbeddings());
         case PENDING:
             return boost::make_shared<PendingResponse>(commandResult.getDescription());
         }

--- a/src/drivers/QtTestDriver.cpp
+++ b/src/drivers/QtTestDriver.cpp
@@ -24,7 +24,7 @@ const InvokeResult QtTestStep::invokeStepBody() {
     } else {
         file.open();
         QTextStream ts(&file);
-        return InvokeResult::failure(ts.readAll().toLocal8Bit());
+        return InvokeResult::failure(ts.readAll().toStdString());
     }
 }
 

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -13,21 +13,6 @@ using namespace testing;
 
 using boost::assign::list_of;
 
-namespace cucumber {
-namespace internal {
-
-void PrintTo(const Embedding& embedding, std::ostream* os) {
-    *os << "{src: \"" << embedding.src << "\"; mime_type: \"" << embedding.mime << "\"; label: \""
-        << embedding.label << "\"}";
-}
-
-bool operator==(const Embedding& lhs, const Embedding& rhs) {
-    return lhs.src == rhs.src && lhs.mime == rhs.mime && lhs.label == rhs.label;
-}
-
-} // namespace internal
-} // namespace cucumber
-
 class MockCukeEngine : public CukeEngine {
 public:
     MOCK_CONST_METHOD1(stepMatches, std::vector<StepMatch>(const std::string & name));

--- a/tests/unit/BasicStepTest.cpp
+++ b/tests/unit/BasicStepTest.cpp
@@ -1,10 +1,13 @@
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <cucumber-cpp/internal/drivers/GenericDriver.hpp>
 
 using namespace cucumber::internal;
+using namespace testing;
 
 #define PENDING_STEP_DESCRIPTION "A description"
+
+namespace {
 
 class PendingStep : public GenericStep {
     void body() {
@@ -18,18 +21,99 @@ class PendingStepWithDescription : public GenericStep {
     }
 };
 
+const char* embedding_src = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQ"
+                            "GAhKmMIQAAAABJRU5ErkJggg==";
+const char* embedding_mime = "image/png;base64";
+const char* embedding_label = "Embedded image";
+
+class SuccessfulStep : public GenericStep {
+    void body() {
+        embed(embedding_src, embedding_mime, embedding_label);
+    }
+};
+
+class FailedStepThrowingException : public GenericStep {
+    void body() {
+        embed(embedding_src, embedding_mime, embedding_label);
+        throw std::runtime_error("runtime_error");
+    }
+};
+
+class FailedStepThrowingString : public GenericStep {
+    void body() {
+        embed(embedding_src, embedding_mime, embedding_label);
+        throw std::string("string");
+    }
+};
+
+class FailedStepThrowingCharacterArray : public GenericStep {
+    void body() {
+        embed(embedding_src, embedding_mime, embedding_label);
+        throw(const char*)("char*");
+    }
+};
+
+class Dummy {};
+
+class FailedStepThrowingUnknown : public GenericStep {
+    void body() {
+        embed(embedding_src, embedding_mime, embedding_label);
+        throw Dummy();
+    }
+};
+
 static const InvokeArgs NO_INVOKE_ARGS;
 
+} // anonymous namespace
+
 TEST(BasicStepTest, handlesPendingSteps) {
-    PendingStep pendingStep;
-    PendingStepWithDescription pendingStepWithDescription;
     InvokeResult result;
 
-    result = pendingStep.invoke(&NO_INVOKE_ARGS);
-    ASSERT_TRUE(result.isPending());
-    ASSERT_STREQ("", result.getDescription().c_str());
+    result = PendingStep().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), PENDING);
+    ASSERT_EQ(result.getDescription(), "");
+    ASSERT_THAT(result.getEmbeddings(), IsEmpty());
 
-    result = pendingStepWithDescription.invoke(&NO_INVOKE_ARGS);
-    ASSERT_TRUE(result.isPending());
-    ASSERT_STREQ(PENDING_STEP_DESCRIPTION, result.getDescription().c_str());
+    result = PendingStepWithDescription().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), PENDING);
+    ASSERT_EQ(result.getDescription(), PENDING_STEP_DESCRIPTION);
+    ASSERT_THAT(result.getEmbeddings(), IsEmpty());
+}
+
+TEST(BasicStepTest, handlesSuccessfulStep) {
+    InvokeResult result;
+
+    result = SuccessfulStep().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), SUCCESS);
+    ASSERT_EQ(result.getDescription(), "");
+    ASSERT_THAT(result.getEmbeddings(),
+                ElementsAre(Embedding(embedding_src, embedding_mime, embedding_label)));
+}
+
+TEST(BasicStepTest, handlesFailedStep) {
+    InvokeResult result;
+
+    result = FailedStepThrowingException().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), FAILURE);
+    ASSERT_EQ(result.getDescription(), "runtime_error");
+    ASSERT_THAT(result.getEmbeddings(),
+                ElementsAre(Embedding(embedding_src, embedding_mime, embedding_label)));
+
+    result = FailedStepThrowingString().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), FAILURE);
+    ASSERT_EQ(result.getDescription(), "string");
+    ASSERT_THAT(result.getEmbeddings(),
+                ElementsAre(Embedding(embedding_src, embedding_mime, embedding_label)));
+
+    result = FailedStepThrowingCharacterArray().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), FAILURE);
+    ASSERT_EQ(result.getDescription(), "char*");
+    ASSERT_THAT(result.getEmbeddings(),
+                ElementsAre(Embedding(embedding_src, embedding_mime, embedding_label)));
+
+    result = FailedStepThrowingUnknown().invoke(&NO_INVOKE_ARGS);
+    ASSERT_EQ(result.getType(), FAILURE);
+    ASSERT_EQ(result.getDescription(), "Unknown exception");
+    ASSERT_THAT(result.getEmbeddings(),
+                ElementsAre(Embedding(embedding_src, embedding_mime, embedding_label)));
 }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm looking into cucumber-cpp for my company.
We need to be able to embed text or images into the reports, but that feature is not available when using the wire protocol.

This patch is the 4th of a series of 4, respectively impacting _cucumber-ruby_, _cucumber-ruby-core_, _cucumber-ruby-wire_ and _cucumber-cpp_.

Basically, the idea is to allow embeddings to be specified in the success or fail responses sent through the wire protocol. E.g.:
```
["success",{"embeddings":[{"label":"Embedded text","mime_type":"text/plain","src":"Some text"}]}]
["fail",{"embeddings":[{"label":"Embedded image","mime_type":"image/png;base64","src":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}],"message":"There was no  banana"}]
```

The patch on _cucumber-ruby_ (cucumber/cucumber-ruby#1354) will let formatters access embeddings stored in a step result.
The patch on _cucumber-ruby-core_ (cucumber/cucumber-ruby-core#170) will store in the step result the embeddings returned by the step invocation.
The patch on _cucumber-ruby-wire_ (cucumber/cucumber-ruby-wire#20) will allow the embeddings stored in the wire response to be returned by the wire-based step invocation process.
The patch on _cucumber-cpp_ (cucumber/cucumber-cpp#223) will allow C++ steps to send embeddings through wire responses.

Note: embeddings were not considered to be useful for pending steps, but support should be possible if required.

## Details

<!--- Describe your changes in detail -->

This patch:
- Redesign the `invokeStep()` method to return an `InvokeResult` instead of relying on implicit success or exceptions.
- Add an `embed()` function to allow steps to declare embeddings. The embeddings of a step are temporarily stored within that step.
- Once the result of a step is known, store the embeddings in the `InvokeResult`, then in the `WireResponse` object.
- Serialize the embeddings from the `WireResponse` in the packet to be sent.

Patches on _cucumber-ruby_, _cucumber-ruby-core_, _cucumber-ruby-wire_ have been submitted for integration in cucumber 4.x, but the changes on _cucumber-cpp_ should be backward compatible with cucumber 2.x. Embeddings will just be ignored.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test on the redesign of the `invokeStep()` method, serialization of embeddings and creation of `WireResponse` from `InvokeResult`.
Still need to look at E2E tests (suggestions welcomed).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [ ] I have verified whether my change requires changes to the documentation
- [ ] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
