### PR TITLE
Support step definitions with multi-byte characters

### DIFF
--- a/3rdparty/json_spirit/CMakeLists.txt
+++ b/3rdparty/json_spirit/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(json_spirit.header INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_stream_reader.h
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_value.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_writer_options.h
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_writer_template.h
 )
 target_include_directories(json_spirit.header SYSTEM
@@ -22,5 +23,6 @@ add_library(json_spirit STATIC EXCLUDE_FROM_ALL
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_value.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_writer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_writer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/json_spirit_writer_options.h
 )
 target_link_libraries(json_spirit PUBLIC json_spirit.header)

--- a/3rdparty/json_spirit/json_spirit.h
+++ b/3rdparty/json_spirit/json_spirit.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT
 #define JSON_SPIRIT
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once

--- a/3rdparty/json_spirit/json_spirit.vcproj
+++ b/3rdparty/json_spirit/json_spirit.vcproj
@@ -199,6 +199,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\json_spirit_writer_options.h"
+				>
+			</File>
+			<File
 				RelativePath=".\json_spirit_writer_template.h"
 				>
 			</File>

--- a/3rdparty/json_spirit/json_spirit_error_position.h
+++ b/3rdparty/json_spirit/json_spirit_error_position.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT_ERROR_POSITION
 #define JSON_SPIRIT_ERROR_POSITION
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once
@@ -48,7 +48,7 @@ namespace json_spirit
         return ( reason_ == lhs.reason_ ) &&
                ( line_   == lhs.line_ ) &&
                ( column_ == lhs.column_ ); 
-}
+    }
 }
 
 #endif

--- a/3rdparty/json_spirit/json_spirit_reader.cpp
+++ b/3rdparty/json_spirit/json_spirit_reader.cpp
@@ -1,137 +1,137 @@
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #include "json_spirit_reader.h"
 #include "json_spirit_reader_template.h"
 
 using namespace json_spirit;
 
-bool json_spirit::read( const std::string& s, Value& value )
-{
-    return read_string( s, value );
-}
+#ifdef JSON_SPIRIT_VALUE_ENABLED
+    bool json_spirit::read( const std::string& s, Value& value )
+    {
+        return read_string( s, value );
+    }
+    
+    void json_spirit::read_or_throw( const std::string& s, Value& value )
+    {
+        read_string_or_throw( s, value );
+    }
 
-void json_spirit::read_or_throw( const std::string& s, Value& value )
-{
-    read_string_or_throw( s, value );
-}
+    bool json_spirit::read( std::istream& is, Value& value )
+    {
+        return read_stream( is, value );
+    }
 
-bool json_spirit::read( std::istream& is, Value& value )
-{
-    return read_stream( is, value );
-}
+    void json_spirit::read_or_throw( std::istream& is, Value& value )
+    {
+        read_stream_or_throw( is, value );
+    }
 
-void json_spirit::read_or_throw( std::istream& is, Value& value )
-{
-    read_stream_or_throw( is, value );
-}
+    bool json_spirit::read( std::string::const_iterator& begin, std::string::const_iterator end, Value& value )
+    {
+        return read_range( begin, end, value );
+    }
 
-bool json_spirit::read( std::string::const_iterator& begin, std::string::const_iterator end, Value& value )
-{
-    return read_range( begin, end, value );
-}
-
-void json_spirit::read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, Value& value )
-{
-    begin = read_range_or_throw( begin, end, value );
-}
-
-#ifndef BOOST_NO_STD_WSTRING
-
-bool json_spirit::read( const std::wstring& s, wValue& value )
-{
-    return read_string( s, value );
-}
-
-void json_spirit::read_or_throw( const std::wstring& s, wValue& value )
-{
-    read_string_or_throw( s, value );
-}
-
-bool json_spirit::read( std::wistream& is, wValue& value )
-{
-    return read_stream( is, value );
-}
-
-void json_spirit::read_or_throw( std::wistream& is, wValue& value )
-{
-    read_stream_or_throw( is, value );
-}
-
-bool json_spirit::read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value )
-{
-    return read_range( begin, end, value );
-}
-
-void json_spirit::read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value )
-{
-    begin = read_range_or_throw( begin, end, value );
-}
-
+    void json_spirit::read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, Value& value )
+    {
+        begin = read_range_or_throw( begin, end, value );
+    }
 #endif
 
-bool json_spirit::read( const std::string& s, mValue& value )
-{
-    return read_string( s, value );
-}
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    bool json_spirit::read( const std::wstring& s, wValue& value )
+    {
+        return read_string( s, value );
+    }
 
-void json_spirit::read_or_throw( const std::string& s, mValue& value )
-{
-    read_string_or_throw( s, value );
-}
+    void json_spirit::read_or_throw( const std::wstring& s, wValue& value )
+    {
+        read_string_or_throw( s, value );
+    }
 
-bool json_spirit::read( std::istream& is, mValue& value )
-{
-    return read_stream( is, value );
-}
+    bool json_spirit::read( std::wistream& is, wValue& value )
+    {
+        return read_stream( is, value );
+    }
 
-void json_spirit::read_or_throw( std::istream& is, mValue& value )
-{
-    read_stream_or_throw( is, value );
-}
+    void json_spirit::read_or_throw( std::wistream& is, wValue& value )
+    {
+        read_stream_or_throw( is, value );
+    }
 
-bool json_spirit::read( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value )
-{
-    return read_range( begin, end, value );
-}
+    bool json_spirit::read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value )
+    {
+        return read_range( begin, end, value );
+    }
 
-void json_spirit::read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value )
-{
-    begin = read_range_or_throw( begin, end, value );
-}
+    void json_spirit::read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value )
+    {
+        begin = read_range_or_throw( begin, end, value );
+    }
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
+    bool json_spirit::read( const std::string& s, mValue& value )
+    {
+        return read_string( s, value );
+    }
 
-bool json_spirit::read( const std::wstring& s, wmValue& value )
-{
-    return read_string( s, value );
-}
+    void json_spirit::read_or_throw( const std::string& s, mValue& value )
+    {
+        read_string_or_throw( s, value );
+    }
+    
+    bool json_spirit::read( std::istream& is, mValue& value )
+    {
+        return read_stream( is, value );
+    }
 
-void json_spirit::read_or_throw( const std::wstring& s, wmValue& value )
-{
-    read_string_or_throw( s, value );
-}
+    void json_spirit::read_or_throw( std::istream& is, mValue& value )
+    {
+        read_stream_or_throw( is, value );
+    }
 
-bool json_spirit::read( std::wistream& is, wmValue& value )
-{
-    return read_stream( is, value );
-}
+    bool json_spirit::read( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value )
+    {
+        return read_range( begin, end, value );
+    }
 
-void json_spirit::read_or_throw( std::wistream& is, wmValue& value )
-{
-    read_stream_or_throw( is, value );
-}
+    void json_spirit::read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value )
+    {
+        begin = read_range_or_throw( begin, end, value );
+    }
+#endif
 
-bool json_spirit::read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value )
-{
-    return read_range( begin, end, value );
-}
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    bool json_spirit::read( const std::wstring& s, wmValue& value )
+    {
+        return read_string( s, value );
+    }
 
-void json_spirit::read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value )
-{
-    begin = read_range_or_throw( begin, end, value );
-}
+    void json_spirit::read_or_throw( const std::wstring& s, wmValue& value )
+    {
+        read_string_or_throw( s, value );
+    }
 
+    bool json_spirit::read( std::wistream& is, wmValue& value )
+    {
+        return read_stream( is, value );
+    }
+
+    void json_spirit::read_or_throw( std::wistream& is, wmValue& value )
+    {
+        read_stream_or_throw( is, value );
+    }
+
+    bool json_spirit::read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value )
+    {
+        return read_range( begin, end, value );
+    }
+
+    void json_spirit::read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value )
+    {
+        begin = read_range_or_throw( begin, end, value );
+    }
 #endif

--- a/3rdparty/json_spirit/json_spirit_reader.h
+++ b/3rdparty/json_spirit/json_spirit_reader.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT_READER
 #define JSON_SPIRIT_READER
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once
@@ -18,6 +18,7 @@ namespace json_spirit
 {
     // functions to reads a JSON values
 
+#ifdef JSON_SPIRIT_VALUE_ENABLED
     bool read( const std::string& s, Value& value );
     bool read( std::istream& is,     Value& value );
     bool read( std::string::const_iterator& begin, std::string::const_iterator end, Value& value );
@@ -25,9 +26,9 @@ namespace json_spirit
     void read_or_throw( const std::string& s, Value& value );  
     void read_or_throw( std::istream& is,     Value& value );
     void read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, Value& value );
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
-
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
     bool read( const std::wstring& s, wValue& value );
     bool read( std::wistream&  is,    wValue& value );
     bool read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value );    
@@ -35,9 +36,9 @@ namespace json_spirit
     void read_or_throw( const std::wstring& s, wValue& value );
     void read_or_throw( std::wistream& is,     wValue& value );
     void read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wValue& value );
-
 #endif
 
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
     bool read( const std::string& s, mValue& value );
     bool read( std::istream& is,     mValue& value );
     bool read( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value );
@@ -45,9 +46,9 @@ namespace json_spirit
     void read_or_throw( const std::string& s, mValue& value );  
     void read_or_throw( std::istream& is,     mValue& value );
     void read_or_throw( std::string::const_iterator& begin, std::string::const_iterator end, mValue& value );
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
-
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
     bool read( const std::wstring& s, wmValue& value );
     bool read( std::wistream& is,     wmValue& value );
     bool read( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value );    
@@ -55,7 +56,6 @@ namespace json_spirit
     void read_or_throw( const std::wstring& s, wmValue& value );
     void read_or_throw( std::wistream& is,     wmValue& value );
     void read_or_throw( std::wstring::const_iterator& begin, std::wstring::const_iterator end, wmValue& value );
-
 #endif
 }
 

--- a/3rdparty/json_spirit/json_spirit_reader_template.h
+++ b/3rdparty/json_spirit/json_spirit_reader_template.h
@@ -1,10 +1,14 @@
 #ifndef JSON_SPIRIT_READER_TEMPLATE
 #define JSON_SPIRIT_READER_TEMPLATE
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
 
 #include "json_spirit_value.h"
 #include "json_spirit_error_position.h"
@@ -484,7 +488,7 @@ namespace json_spirit
                     ;
 
                 string_ 
-                    = lexeme_d // this causes white space inside a string to be retained
+                    = lexeme_d // this causes white space and what would appear to be comments inside a string to be retained
                       [
                           confix_p
                           ( 
@@ -515,25 +519,6 @@ namespace json_spirit
     };
 
     template< class Iter_type, class Value_type >
-    Iter_type read_range_or_throw( Iter_type begin, Iter_type end, Value_type& value )
-    {
-        Semantic_actions< Value_type, Iter_type > semantic_actions( value );
-     
-        const spirit_namespace::parse_info< Iter_type > info = 
-                            spirit_namespace::parse( begin, end, 
-                                                    Json_grammer< Value_type, Iter_type >( semantic_actions ), 
-                                                    spirit_namespace::space_p );
-
-        if( !info.hit )
-        {
-            assert( false ); // in theory exception should already have been thrown
-            throw_error( info.stop, "error" );
-        }
-
-        return info.stop;
-    }
-
-    template< class Iter_type, class Value_type >
     void add_posn_iter_and_read_range_or_throw( Iter_type begin, Iter_type end, Value_type& value )
     {
         typedef spirit_namespace::position_iterator< Iter_type > Posn_iter_t;
@@ -542,35 +527,6 @@ namespace json_spirit
         const Posn_iter_t posn_end( end, end );
      
         read_range_or_throw( posn_begin, posn_end, value );
-    }
-
-    template< class Iter_type, class Value_type >
-    bool read_range( Iter_type& begin, Iter_type end, Value_type& value )
-    {
-        try
-        {
-            begin = read_range_or_throw( begin, end, value );
-
-            return true;
-        }
-        catch( ... )
-        {
-            return false;
-        }
-    }
-
-    template< class String_type, class Value_type >
-    void read_string_or_throw( const String_type& s, Value_type& value )
-    {
-        add_posn_iter_and_read_range_or_throw( s.begin(), s.end(), value );
-    }
-
-    template< class String_type, class Value_type >
-    bool read_string( const String_type& s, Value_type& value )
-    {
-        typename String_type::const_iterator begin = s.begin();
-
-        return read_range( begin, s.end(), value );
     }
 
     template< class Istream_type >
@@ -592,6 +548,84 @@ namespace json_spirit
         Mp_iter end_;
     };
 
+    // reads a JSON Value from a pair of input iterators throwing an exception on invalid input, e.g.
+    //
+    // string::const_iterator start = str.begin();
+    // const string::const_iterator next = read_range_or_throw( str.begin(), str.end(), value );
+    //
+    // The iterator 'next' will point to the character past the 
+    // last one read.
+    //
+    template< class Iter_type, class Value_type >
+    Iter_type read_range_or_throw( Iter_type begin, Iter_type end, Value_type& value )
+    {
+        Semantic_actions< Value_type, Iter_type > semantic_actions( value );
+     
+        const spirit_namespace::parse_info< Iter_type > info = 
+                            spirit_namespace::parse( begin, end, 
+                                                    Json_grammer< Value_type, Iter_type >( semantic_actions ), 
+                                                    spirit_namespace::space_p | 
+                                                    spirit_namespace::comment_p("//") | 
+                                                    spirit_namespace::comment_p("/*", "*/") );
+
+        if( !info.hit )
+        {
+            assert( false ); // in theory exception should already have been thrown
+            throw_error( info.stop, "error" );
+        }
+
+        return info.stop;
+    }
+
+    // reads a JSON Value from a pair of input iterators, e.g.
+    //
+    // string::const_iterator start = str.begin();
+    // const bool success = read_string( start, str.end(), value );
+    //
+    // The iterator 'start' will point to the character past the 
+    // last one read.
+    //
+    template< class Iter_type, class Value_type >
+    bool read_range( Iter_type& begin, Iter_type end, Value_type& value )
+    {
+        try
+        {
+            begin = read_range_or_throw( begin, end, value );
+
+            return true;
+        }
+        catch( ... )
+        {
+            return false;
+        }
+    }
+
+    // reads a JSON Value from a string, e.g.
+    //
+    // const bool success = read_string( str, value );
+    //
+    template< class String_type, class Value_type >
+    bool read_string( const String_type& s, Value_type& value )
+    {
+        typename String_type::const_iterator begin = s.begin();
+
+        return read_range( begin, s.end(), value );
+    }
+
+    // reads a JSON Value from a string throwing an exception on invalid input, e.g.
+    //
+    // read_string_or_throw( is, value );
+    //
+    template< class String_type, class Value_type >
+    void read_string_or_throw( const String_type& s, Value_type& value )
+    {
+        add_posn_iter_and_read_range_or_throw( s.begin(), s.end(), value );
+    }
+
+    // reads a JSON Value from a stream, e.g.
+    //
+    // const bool success = read_stream( is, value );
+    //
     template< class Istream_type, class Value_type >
     bool read_stream( Istream_type& is, Value_type& value )
     {
@@ -600,6 +634,10 @@ namespace json_spirit
         return read_range( mp_iters.begin_, mp_iters.end_, value );
     }
 
+    // reads a JSON Value from a stream throwing an exception on invalid input, e.g.
+    //
+    // read_stream_or_throw( is, value );
+    //
     template< class Istream_type, class Value_type >
     void read_stream_or_throw( Istream_type& is, Value_type& value )
     {

--- a/3rdparty/json_spirit/json_spirit_stream_reader.h
+++ b/3rdparty/json_spirit/json_spirit_stream_reader.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT_READ_STREAM
 #define JSON_SPIRIT_READ_STREAM
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once

--- a/3rdparty/json_spirit/json_spirit_utils.h
+++ b/3rdparty/json_spirit/json_spirit_utils.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT_UTILS
 #define JSON_SPIRIT_UTILS
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once
@@ -37,9 +37,11 @@ namespace json_spirit
         }
     }
 
+#ifdef JSON_SPIRIT_VALUE_ENABLED
     typedef std::map< std::string, Value > Mapped_obj;
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
     typedef std::map< std::wstring, wValue > wMapped_obj;
 #endif
 

--- a/3rdparty/json_spirit/json_spirit_value.cpp
+++ b/3rdparty/json_spirit/json_spirit_value.cpp
@@ -1,8 +1,6 @@
-/* Copyright (c) 2007 John W Wilkinson
+//          Copyright John W. Wilkinson 2007 - 2014
+// Distributed under the MIT License, see accompanying file LICENSE.txt
 
-   This source code can be used for any purpose as long as
-   this comment is retained. */
-
-// json spirit version 2.00
+// json spirit version 4.08
 
 #include "json_spirit_value.h"

--- a/3rdparty/json_spirit/json_spirit_value.h
+++ b/3rdparty/json_spirit/json_spirit_value.h
@@ -1,10 +1,10 @@
 #ifndef JSON_SPIRIT_VALUE
 #define JSON_SPIRIT_VALUE
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once
@@ -21,10 +21,20 @@
 #include <boost/shared_ptr.hpp> 
 #include <boost/variant.hpp> 
 
+// comment out the value types you don't need to reduce build times and intermediate file sizes
+#define JSON_SPIRIT_VALUE_ENABLED
+#define JSON_SPIRIT_WVALUE_ENABLED
+#define JSON_SPIRIT_MVALUE_ENABLED
+#define JSON_SPIRIT_WMVALUE_ENABLED
+
 namespace json_spirit
 {
     enum Value_type{ obj_type, array_type, str_type, bool_type, int_type, real_type, null_type };
 
+    static std::string value_type_to_string( Value_type vtype );
+
+    struct Null{};
+    
     template< class Config >    // Config determines whether the value uses std::string or std::wstring and
                                 // whether JSON Objects are represented as vectors or maps
     class Value_impl
@@ -47,6 +57,12 @@ namespace json_spirit
         Value_impl( boost::int64_t     value );
         Value_impl( boost::uint64_t    value );
         Value_impl( double             value );
+
+        template< class Iter >
+        Value_impl( Iter first, Iter last );    // constructor from containers, e.g. std::vector or std::list
+
+        template< BOOST_VARIANT_ENUM_PARAMS( typename T ) >
+        Value_impl( const boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >& variant ); // constructor for compatible variant types
 
         Value_impl( const Value_impl& other );
 
@@ -80,13 +96,32 @@ namespace json_spirit
 
         void check_type( const Value_type vtype ) const;
 
-        typedef boost::variant< String_type, 
-                                boost::recursive_wrapper< Object >, boost::recursive_wrapper< Array >, 
-                                bool, boost::int64_t, double > Variant;
+        typedef boost::variant< boost::recursive_wrapper< Object >, boost::recursive_wrapper< Array >, 
+                                String_type, bool, boost::int64_t, double, Null, boost::uint64_t > Variant;
 
-        Value_type type_;
         Variant v_;
-        bool is_uint64_;
+
+        class Variant_converter_visitor : public boost::static_visitor< Variant > 
+        {
+        public:
+         
+              template< typename T, typename A, template< typename, typename > class Cont >
+              Variant operator()( const Cont< T, A >& cont ) const 
+              {
+                  return Array( cont.begin(), cont.end() );
+              }
+             
+              Variant operator()( int i ) const 
+              {
+                  return static_cast< boost::int64_t >( i );
+              }
+           
+              template<class T>
+              Variant operator()( const T& t ) const 
+              {
+                  return t;
+              }
+        };
     };
 
     // vector objects
@@ -97,6 +132,10 @@ namespace json_spirit
         typedef typename Config::String_type String_type;
         typedef typename Config::Value_type Value_type;
 
+        Pair_impl()
+        {
+        }
+
         Pair_impl( const String_type& name, const Value_type& value );
 
         bool operator==( const Pair_impl& lhs ) const;
@@ -105,6 +144,7 @@ namespace json_spirit
         Value_type value_;
     };
 
+#if defined( JSON_SPIRIT_VALUE_ENABLED ) || defined( JSON_SPIRIT_WVALUE_ENABLED )
     template< class String >
     struct Config_vector
     {
@@ -121,30 +161,32 @@ namespace json_spirit
             return obj.back().value_;
         }
                 
-        static String_type get_name( const Pair_type& pair )
+        static const String_type& get_name( const Pair_type& pair )
         {
             return pair.name_;
         }
                 
-        static Value_type get_value( const Pair_type& pair )
+        static const Value_type& get_value( const Pair_type& pair )
         {
             return pair.value_;
         }
     };
+#endif
 
     // typedefs for ASCII
 
+#ifdef JSON_SPIRIT_VALUE_ENABLED
     typedef Config_vector< std::string > Config;
 
     typedef Config::Value_type  Value;
     typedef Config::Pair_type   Pair;
     typedef Config::Object_type Object;
     typedef Config::Array_type  Array;
+#endif
 
     // typedefs for Unicode
 
-#ifndef BOOST_NO_STD_WSTRING
-
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
     typedef Config_vector< std::wstring > wConfig;
 
     typedef wConfig::Value_type  wValue;
@@ -155,6 +197,7 @@ namespace json_spirit
 
     // map objects
 
+#if defined( JSON_SPIRIT_MVALUE_ENABLED ) || defined( JSON_SPIRIT_WMVALUE_ENABLED )
     template< class String >
     struct Config_map
     {
@@ -162,135 +205,134 @@ namespace json_spirit
         typedef Value_impl< Config_map > Value_type;
         typedef std::vector< Value_type > Array_type;
         typedef std::map< String_type, Value_type > Object_type;
-        typedef typename Object_type::value_type Pair_type;
+        typedef std::pair< const String_type, Value_type > Pair_type;
 
         static Value_type& add( Object_type& obj, const String_type& name, const Value_type& value )
         {
             return obj[ name ] = value;
         }
                 
-        static String_type get_name( const Pair_type& pair )
+        static const String_type& get_name( const Pair_type& pair )
         {
             return pair.first;
         }
                 
-        static Value_type get_value( const Pair_type& pair )
+        static const Value_type& get_value( const Pair_type& pair )
         {
             return pair.second;
         }
     };
+#endif
 
     // typedefs for ASCII
 
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
     typedef Config_map< std::string > mConfig;
 
     typedef mConfig::Value_type  mValue;
     typedef mConfig::Object_type mObject;
     typedef mConfig::Array_type  mArray;
+#endif
 
     // typedefs for Unicode
 
-#ifndef BOOST_NO_STD_WSTRING
-
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
     typedef Config_map< std::wstring > wmConfig;
 
     typedef wmConfig::Value_type  wmValue;
     typedef wmConfig::Object_type wmObject;
     typedef wmConfig::Array_type  wmArray;
-
 #endif
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     //
     // implementation
 
+    inline bool operator==( const Null&, const Null& )
+    {
+        return true;
+    }
+
     template< class Config >
     const Value_impl< Config > Value_impl< Config >::null;
 
     template< class Config >
     Value_impl< Config >::Value_impl()
-    :   type_( null_type )
-    ,   is_uint64_( false )
+    :   v_( Null() )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( const Const_str_ptr value )
-    :   type_( str_type )
-    ,   v_( String_type( value ) )
-    ,   is_uint64_( false )
+    :  v_( String_type( value ) )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( const String_type& value )
-    :   type_( str_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( const Object& value )
-    :   type_( obj_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( const Array& value )
-    :   type_( array_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( bool value )
-    :   type_( bool_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( int value )
-    :   type_( int_type )
-    ,   v_( static_cast< boost::int64_t >( value ) )
-    ,   is_uint64_( false )
+    :   v_( static_cast< boost::int64_t >( value ) )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( boost::int64_t value )
-    :   type_( int_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( boost::uint64_t value )
-    :   type_( int_type )
-    ,   v_( static_cast< boost::int64_t >( value ) )
-    ,   is_uint64_( true )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( double value )
-    :   type_( real_type )
-    ,   v_( value )
-    ,   is_uint64_( false )
+    :   v_( value )
     {
     }
 
     template< class Config >
     Value_impl< Config >::Value_impl( const Value_impl< Config >& other )
-    :   type_( other.type() )
-    ,   v_( other.v_ )
-    ,   is_uint64_( other.is_uint64_ )
+    :   v_( other.v_ )
+    {
+    }
+
+    template< class Config >
+    template< class Iter >
+    Value_impl< Config >::Value_impl( Iter first, Iter last )
+    :   v_( Array( first, last ) )
+    {
+    }
+
+    template< class Config >
+    template< BOOST_VARIANT_ENUM_PARAMS( typename T ) >
+    Value_impl< Config >::Value_impl( const boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >& variant )
+    :   v_( boost::apply_visitor( Variant_converter_visitor(), variant) )
     {
     }
 
@@ -299,9 +341,7 @@ namespace json_spirit
     {
         Value_impl tmp( lhs );
 
-        std::swap( type_, tmp.type_ );
         std::swap( v_, tmp.v_ );
-        std::swap( is_uint64_, tmp.is_uint64_ );
 
         return *this;
     }
@@ -319,13 +359,18 @@ namespace json_spirit
     template< class Config >
     Value_type Value_impl< Config >::type() const
     {
-        return type_;
+        if( is_uint64() )
+        {
+            return int_type;
+        }
+
+        return static_cast< Value_type >( v_.which() );
     }
 
     template< class Config >
     bool Value_impl< Config >::is_uint64() const
     {
-        return is_uint64_;
+        return v_.which() == null_type + 1;
     }
 
     template< class Config >
@@ -341,7 +386,7 @@ namespace json_spirit
         {
             std::ostringstream os;
 
-            os << "value type is " << type() << " not " << vtype;
+            os << "get_value< " << value_type_to_string( vtype ) << " > called on " << value_type_to_string( type() ) << " Value";
 
             throw std::runtime_error( os.str() );
         }
@@ -350,7 +395,7 @@ namespace json_spirit
     template< class Config >
     const typename Config::String_type& Value_impl< Config >::get_str() const
     {
-        check_type(  str_type );
+        check_type( str_type );
 
         return *boost::get< String_type >( &v_ );
     }
@@ -366,7 +411,7 @@ namespace json_spirit
     template< class Config >
     const typename Value_impl< Config >::Array& Value_impl< Config >::get_array() const
     {
-        check_type(  array_type );
+        check_type( array_type );
 
         return *boost::get< Array >( &v_ );
     }
@@ -374,7 +419,7 @@ namespace json_spirit
     template< class Config >
     bool Value_impl< Config >::get_bool() const
     {
-        check_type(  bool_type );
+        check_type( bool_type );
 
         return boost::get< bool >( v_ );
     }
@@ -382,7 +427,7 @@ namespace json_spirit
     template< class Config >
     int Value_impl< Config >::get_int() const
     {
-        check_type(  int_type );
+        check_type( int_type );
 
         return static_cast< int >( get_int64() );
     }
@@ -390,7 +435,12 @@ namespace json_spirit
     template< class Config >
     boost::int64_t Value_impl< Config >::get_int64() const
     {
-        check_type(  int_type );
+        check_type( int_type );
+
+        if( is_uint64() )
+        {
+            return static_cast< boost::int64_t >( get_uint64() );
+        }
 
         return boost::get< boost::int64_t >( v_ );
     }
@@ -398,9 +448,14 @@ namespace json_spirit
     template< class Config >
     boost::uint64_t Value_impl< Config >::get_uint64() const
     {
-        check_type(  int_type );
+        check_type( int_type );
 
-        return static_cast< boost::uint64_t >( get_int64() );
+        if( !is_uint64() )
+        {
+            return static_cast< boost::uint64_t >( get_int64() );
+        }
+
+        return boost::get< boost::uint64_t >( v_ );
     }
 
     template< class Config >
@@ -412,7 +467,7 @@ namespace json_spirit
                                : static_cast< double >( get_int64() );
         }
 
-        check_type(  real_type );
+        check_type( real_type );
 
         return boost::get< double >( v_ );
     }
@@ -420,7 +475,7 @@ namespace json_spirit
     template< class Config >
     typename Value_impl< Config >::Object& Value_impl< Config >::get_obj()
     {
-        check_type(  obj_type );
+        check_type( obj_type );
 
         return *boost::get< Object >( &v_ );
     }
@@ -428,7 +483,7 @@ namespace json_spirit
     template< class Config >
     typename Value_impl< Config >::Array& Value_impl< Config >::get_array()
     {
-        check_type(  array_type );
+        check_type( array_type );
 
         return *boost::get< Array >( &v_ );
     }
@@ -526,6 +581,24 @@ namespace json_spirit
     T Value_impl< Config >::get_value() const
     {
         return internal_::get_value( *this, internal_::Type_to_type< T >() );
+    }
+
+    static std::string value_type_to_string( const Value_type vtype )
+    {
+        switch( vtype )
+        {
+            case obj_type: return "Object";
+            case array_type: return "Array";
+            case str_type: return "string";
+            case bool_type: return "boolean";
+            case int_type: return "integer";
+            case real_type: return "real";
+            case null_type: return "null";
+        }
+
+        assert( false );
+
+        return "unknown type";
     }
 }
 

--- a/3rdparty/json_spirit/json_spirit_writer.cpp
+++ b/3rdparty/json_spirit/json_spirit_writer.cpp
@@ -1,95 +1,96 @@
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #include "json_spirit_writer.h"
 #include "json_spirit_writer_template.h"
 
-void json_spirit::write( const Value& value, std::ostream& os )
-{
-    write_stream( value, os, false );
-}
+using namespace json_spirit;
 
-void json_spirit::write_formatted( const Value& value, std::ostream& os )
-{
-    write_stream( value, os, true );
-}
+#ifdef JSON_SPIRIT_VALUE_ENABLED
+    void json_spirit::write( const Value& value, std::ostream& os, int options, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, options, precision_of_doubles );
+    }
+    std::string json_spirit::write( const Value& value, int options, unsigned int precision_of_doubles )
+    {
+        return write_string( value, options, precision_of_doubles );
+    }
 
-std::string json_spirit::write( const Value& value )
-{
-    return write_string( value, false );
-}
+    void json_spirit::write_formatted( const Value& value, std::ostream& os, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, pretty_print, precision_of_doubles );
+    }
 
-std::string json_spirit::write_formatted( const Value& value )
-{
-    return write_string( value, true );
-}
-
-#ifndef BOOST_NO_STD_WSTRING
-
-void json_spirit::write( const wValue& value, std::wostream& os )
-{
-    write_stream( value, os, false );
-}
-
-void json_spirit::write_formatted( const wValue& value, std::wostream& os )
-{
-    write_stream( value, os, true );
-}
-
-std::wstring json_spirit::write( const wValue&  value )
-{
-    return write_string( value, false );
-}
-
-std::wstring json_spirit::write_formatted( const wValue&  value )
-{
-    return write_string( value, true );
-}
-
+    std::string json_spirit::write_formatted( const Value& value, unsigned int precision_of_doubles )
+    {
+        return write_string( value, pretty_print, precision_of_doubles );
+    }
 #endif
 
-void json_spirit::write( const mValue& value, std::ostream& os )
-{
-    write_stream( value, os, false );
-}
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
+    void json_spirit::write( const mValue& value, std::ostream& os, int options, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, options, precision_of_doubles );
+    }
 
-void json_spirit::write_formatted( const mValue& value, std::ostream& os )
-{
-    write_stream( value, os, true );
-}
+    std::string json_spirit::write( const mValue& value, int options, unsigned int precision_of_doubles )
+    {
+        return write_string( value, options, precision_of_doubles );
+    }
 
-std::string json_spirit::write( const mValue& value )
-{
-    return write_string( value, false );
-}
+    void json_spirit::write_formatted( const mValue& value, std::ostream& os, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, pretty_print, precision_of_doubles );
+    }
 
-std::string json_spirit::write_formatted( const mValue& value )
-{
-    return write_string( value, true );
-}
+    std::string json_spirit::write_formatted( const mValue& value, unsigned int precision_of_doubles )
+    {
+        return write_string( value, pretty_print, precision_of_doubles );
+    }
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void json_spirit::write( const wValue& value, std::wostream& os, int options, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, options, precision_of_doubles );
+    }
 
-void json_spirit::write( const wmValue& value, std::wostream& os )
-{
-    write_stream( value, os, false );
-}
+    std::wstring json_spirit::write( const wValue& value, int options, unsigned int precision_of_doubles )
+    {
+        return write_string( value, options, precision_of_doubles );
+    }
 
-void json_spirit::write_formatted( const wmValue& value, std::wostream& os )
-{
-    write_stream( value, os, true );
-}
+    void json_spirit::write_formatted( const wValue& value, std::wostream& os, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, pretty_print, precision_of_doubles );
+    }
 
-std::wstring json_spirit::write( const wmValue&  value )
-{
-    return write_string( value, false );
-}
+    std::wstring json_spirit::write_formatted( const wValue& value, unsigned int precision_of_doubles )
+    {
+        return write_string( value, pretty_print, precision_of_doubles );
+    }
+#endif
 
-std::wstring json_spirit::write_formatted( const wmValue&  value )
-{
-    return write_string( value, true );
-}
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void json_spirit::write_formatted( const wmValue& value, std::wostream& os, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, pretty_print, precision_of_doubles );
+    }
 
+    std::wstring json_spirit::write_formatted( const wmValue& value, unsigned int precision_of_doubles )
+    {
+        return write_string( value, pretty_print, precision_of_doubles );
+    }
+
+    void json_spirit::write( const wmValue& value, std::wostream& os, int options, unsigned int precision_of_doubles )
+    {
+        write_stream( value, os, options, precision_of_doubles );
+    }
+
+    std::wstring json_spirit::write( const wmValue& value, int options, unsigned int precision_of_doubles )
+    {
+        return write_string( value, options, precision_of_doubles );
+    }
 #endif

--- a/3rdparty/json_spirit/json_spirit_writer.h
+++ b/3rdparty/json_spirit/json_spirit_writer.h
@@ -1,49 +1,64 @@
 #ifndef JSON_SPIRIT_WRITER
 #define JSON_SPIRIT_WRITER
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 # pragma once
 #endif
 
 #include "json_spirit_value.h"
+#include "json_spirit_writer_options.h"
 #include <iostream>
 
 namespace json_spirit
 {
-    // functions to convert JSON Values to text, 
-    // the "formatted" versions add whitespace to format the output nicely
+    // these functions to convert JSON Values to text
+    // note the precision used outputing doubles defaults to 17, 
+    // unless the remove_trailing_zeros option is given in which case the default is 16
 
-    void         write          ( const Value& value, std::ostream&  os );
-    void         write_formatted( const Value& value, std::ostream&  os );
-    std::string  write          ( const Value& value );
-    std::string  write_formatted( const Value& value );
-
-#ifndef BOOST_NO_STD_WSTRING
-
-    void         write          ( const wValue& value, std::wostream& os );
-    void         write_formatted( const wValue& value, std::wostream& os );
-    std::wstring write          ( const wValue& value );
-    std::wstring write_formatted( const wValue& value );
-
+#ifdef JSON_SPIRIT_VALUE_ENABLED
+    void         write( const Value&  value, std::ostream&  os, int options = none, unsigned int precision_of_doubles = 0 );
+    std::string  write( const Value&  value, int options = none, unsigned int precision_of_doubles = 0 );
 #endif
 
-    void         write          ( const mValue& value, std::ostream&  os );
-    void         write_formatted( const mValue& value, std::ostream&  os );
-    std::string  write          ( const mValue& value );
-    std::string  write_formatted( const mValue& value );
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
+    void         write( const mValue& value, std::ostream&  os, int options = none, unsigned int precision_of_doubles = 0 );
+    std::string  write( const mValue& value, int options = none, unsigned int precision_of_doubles = 0 );
+#endif
 
-#ifndef BOOST_NO_STD_WSTRING
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void         write( const wValue&  value, std::wostream& os, int options = none, unsigned int precision_of_doubles = 0 );
+    std::wstring write( const wValue&  value, int options = none, unsigned int precision_of_doubles = 0 );
+#endif
 
-    void         write          ( const wmValue& value, std::wostream& os );
-    void         write_formatted( const wmValue& value, std::wostream& os );
-    std::wstring write          ( const wmValue& value );
-    std::wstring write_formatted( const wmValue& value );
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void         write( const wmValue& value, std::wostream& os, int options = none, unsigned int precision_of_doubles = 0 );
+    std::wstring write( const wmValue& value, int options = none, unsigned int precision_of_doubles = 0 );
+#endif
 
+    // these "formatted" versions of the "write" functions are the equivalent of the above functions
+    // with option "pretty_print"
+    
+#ifdef JSON_SPIRIT_VALUE_ENABLED
+    void         write_formatted( const Value& value, std::ostream&  os, unsigned int precision_of_doubles = 0 );
+    std::string  write_formatted( const Value& value, unsigned int precision_of_doubles = 0 );
+#endif
+#ifdef JSON_SPIRIT_MVALUE_ENABLED
+    void         write_formatted( const mValue& value, std::ostream&  os, unsigned int precision_of_doubles = 0 );
+    std::string  write_formatted( const mValue& value, unsigned int precision_of_doubles = 0 );
+#endif
+
+#if defined( JSON_SPIRIT_WVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void         write_formatted( const wValue& value, std::wostream& os, unsigned int precision_of_doubles = 0 );
+    std::wstring write_formatted( const wValue& value, unsigned int precision_of_doubles = 0 );
+#endif
+#if defined( JSON_SPIRIT_WMVALUE_ENABLED ) && !defined( BOOST_NO_STD_WSTRING )
+    void         write_formatted( const wmValue& value, std::wostream& os, unsigned int precision_of_doubles = 0 );
+    std::wstring write_formatted( const wmValue& value, unsigned int precision_of_doubles = 0 );
 #endif
 }
 

--- a/3rdparty/json_spirit/json_spirit_writer_options.h
+++ b/3rdparty/json_spirit/json_spirit_writer_options.h
@@ -1,0 +1,35 @@
+#ifndef JSON_SPIRIT_WRITER_OPTIONS
+#define JSON_SPIRIT_WRITER_OPTIONS
+
+//          Copyright John W. Wilkinson 2007 - 2014
+// Distributed under the MIT License, see accompanying file LICENSE.txt
+
+// json spirit version 4.08
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
+
+namespace json_spirit
+{
+    enum Output_options{ none = 0,              // default options
+
+                         pretty_print = 0x01,   // Add whitespace to format the output nicely.
+
+                         raw_utf8 = 0x02,       // This prevents non-printable characters from being escapted using "\uNNNN" notation.
+                                                // Note, this is an extension to the JSON standard. It disables the escaping of
+                                                // non-printable characters allowing UTF-8 sequences held in 8 bit char strings
+                                                // to pass through unaltered.
+
+                         remove_trailing_zeros = 0x04,
+                                                // no longer used kept for backwards compatibility
+                         single_line_arrays = 0x08,
+                                                // pretty printing except that arrays printed on single lines unless they contain
+                                                // composite elements, i.e. objects or arrays
+                         always_escape_nonascii = 0x10,
+                                                // all unicode wide characters are escaped, i.e. outputed as "\uXXXX", even if they are
+                                                // printable under the current locale, ascii printable chars are not escaped
+                       };
+}
+
+#endif

--- a/3rdparty/json_spirit/json_spirit_writer_template.h
+++ b/3rdparty/json_spirit/json_spirit_writer_template.h
@@ -1,17 +1,23 @@
 #ifndef JSON_SPIRIT_WRITER_TEMPLATE
 #define JSON_SPIRIT_WRITER_TEMPLATE
 
-//          Copyright John W. Wilkinson 2007 - 2009.
+//          Copyright John W. Wilkinson 2007 - 2014
 // Distributed under the MIT License, see accompanying file LICENSE.txt
 
-// json spirit version 4.03
+// json spirit version 4.08
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
 
 #include "json_spirit_value.h"
+#include "json_spirit_writer_options.h"
 
 #include <cassert>
 #include <cwctype>
 #include <sstream>
 #include <iomanip>
+#include <boost/io/ios_state.hpp>
 
 namespace json_spirit
 {
@@ -61,7 +67,7 @@ namespace json_spirit
     }
 
     template< class String_type >
-    String_type add_esc_chars( const String_type& s )
+    String_type add_esc_chars( const String_type& s, bool raw_utf8, bool esc_nonascii )
     {
         typedef typename String_type::const_iterator Iter_type;
         typedef typename String_type::value_type     Char_type;
@@ -76,15 +82,22 @@ namespace json_spirit
 
             if( add_esc_char( c, result ) ) continue;
 
-            const wint_t unsigned_c( ( c >= 0 ) ? c : 256 + c );
-
-            if( std::iswprint( unsigned_c ) )
+            if( raw_utf8 )
             {
                 result += c;
             }
             else
             {
-                result += non_printable_to_string< String_type >( unsigned_c );
+                const wint_t unsigned_c( ( c >= 0 ) ? c : 256 + c );
+
+                if( !esc_nonascii && iswprint( unsigned_c ) )
+                {
+                    result += c;
+                }
+                else
+                {
+                    result += non_printable_to_string< String_type >( unsigned_c );
+                }
             }
         }
 
@@ -106,11 +119,24 @@ namespace json_spirit
 
     public:
 
-        Generator( const Value_type& value, Ostream_type& os, bool pretty )
+        Generator( const Value_type& value, Ostream_type& os, int options, unsigned int precision_of_doubles )
         :   os_( os )
         ,   indentation_level_( 0 )
-        ,   pretty_( pretty )
+        ,   pretty_( ( options & pretty_print ) != 0 || ( options & single_line_arrays ) != 0 )
+        ,   raw_utf8_( ( options & raw_utf8 ) != 0 )
+        ,   esc_nonascii_( ( options & always_escape_nonascii ) != 0 )
+        ,   single_line_arrays_( ( options & single_line_arrays ) != 0 )
+        ,   ios_saver_( os )
         {
+            if( precision_of_doubles > 0 )
+            {
+                precision_of_doubles_ = precision_of_doubles;
+            }
+            else
+            {
+                precision_of_doubles_ = ( options & remove_trailing_zeros ) != 0 ? 16 : 17;
+            }
+
             output( value );
         }
 
@@ -124,9 +150,8 @@ namespace json_spirit
                 case array_type: output( value.get_array() ); break;
                 case str_type:   output( value.get_str() );   break;
                 case bool_type:  output( value.get_bool() );  break;
+                case real_type:  output( value.get_real() );  break;
                 case int_type:   output_int( value );         break;
-                case real_type:  os_ << std::showpoint << std::setprecision( 16 ) 
-                                     << value.get_real();     break;
                 case null_type:  os_ << "null";               break;
                 default: assert( false );
             }
@@ -135,11 +160,6 @@ namespace json_spirit
         void output( const Object_type& obj )
         {
             output_array_or_obj( obj, '{', '}' );
-        }
-
-        void output( const Array_type& arr )
-        {
-            output_array_or_obj( arr, '[', ']' );
         }
 
         void output( const Obj_member_type& member )
@@ -163,12 +183,65 @@ namespace json_spirit
 
         void output( const String_type& s )
         {
-            os_ << '"' << add_esc_chars( s ) << '"';
+            os_ << '"' << add_esc_chars( s, raw_utf8_, esc_nonascii_ ) << '"';
         }
 
         void output( bool b )
         {
             os_ << to_str< String_type >( b ? "true" : "false" );
+        }
+
+        void output( double d )
+        {
+            os_ << std::setprecision( precision_of_doubles_ ) << d;
+        }
+
+        static bool contains_composite_elements( const Array_type& arr )
+        {
+            for( typename Array_type::const_iterator i = arr.begin(); i != arr.end(); ++i )
+            {
+                const Value_type& val = *i;
+
+                if( val.type() == obj_type ||
+                    val.type() == array_type )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        template< class Iter >
+        void output_composite_item( Iter i, Iter last )
+        {
+            output( *i );
+
+            if( ++i != last )
+            {
+                os_ << ',';
+            }
+        }
+
+        void output( const Array_type& arr )
+        {
+            if( single_line_arrays_ && !contains_composite_elements( arr )  )
+            {
+                os_ << '['; space();
+               
+                for( typename Array_type::const_iterator i = arr.begin(); i != arr.end(); ++i )
+                {
+                    output_composite_item( i, arr.end() );
+
+                    space();
+                }
+
+                os_ << ']';
+            }
+            else
+            {
+                output_array_or_obj( arr, '[', ']' );
+            }
         }
 
         template< class T >
@@ -180,14 +253,9 @@ namespace json_spirit
             
             for( typename T::const_iterator i = t.begin(); i != t.end(); ++i )
             {
-                indent(); output( *i );
+                indent();
 
-                typename T::const_iterator next = i;
-
-                if( ++next != t.end())
-                {
-                    os_ << ',';
-                }
+                output_composite_item( i, t.end() );
 
                 new_line();
             }
@@ -222,22 +290,36 @@ namespace json_spirit
         Ostream_type& os_;
         int indentation_level_;
         bool pretty_;
+        bool raw_utf8_;
+        bool esc_nonascii_;
+        bool single_line_arrays_;
+        int precision_of_doubles_;
+        boost::io::basic_ios_all_saver< Char_type > ios_saver_;  // so that ostream state is reset after control is returned to the caller
     };
 
+    // writes JSON Value to a stream, e.g.
+    //
+    // write_stream( value, os, pretty_print );
+    //
     template< class Value_type, class Ostream_type >
-    void write_stream( const Value_type& value, Ostream_type& os, bool pretty )
+    void write_stream( const Value_type& value, Ostream_type& os, int options = none, unsigned int precision_of_doubles = 0 )
     {
-        Generator< Value_type, Ostream_type >( value, os, pretty );
+        os << std::dec;
+        Generator< Value_type, Ostream_type >( value, os, options, precision_of_doubles );
     }
 
+    // writes JSON Value to a stream, e.g.
+    //
+    // const string json_str = write( value, pretty_print );
+    //
     template< class Value_type >
-    typename Value_type::String_type write_string( const Value_type& value, bool pretty )
+    typename Value_type::String_type write_string( const Value_type& value, int options = none, unsigned int precision_of_doubles = 0 )
     {
         typedef typename Value_type::String_type::value_type Char_type;
 
         std::basic_ostringstream< Char_type > os;
 
-        write_stream( value, os, pretty );
+        write_stream( value, os, options, precision_of_doubles );
 
         return os.str();
     }

--- a/features/specific/wire_encoding.feature
+++ b/features/specific/wire_encoding.feature
@@ -24,13 +24,7 @@ Feature: Wire Encoding Feature
       """
     When Cucumber runs the feature
     Then the step output should contain:
-    # EXPECTED
-    #   """
-    #   カラオケ機ASCII
-    #   
-    #   """
-    # ACTUAL
       """
-      \\u00E3\\u0082\\u00AB\\u00E3\\u0083\\u00A9\\u00E3\\u0082\\u00AA\\u00E3\\u0082\\u00B1\\u00E6\\u00A9\\u009FASCII
+      カラオケ機ASCII
 
       """

--- a/features/specific/wire_encoding.feature
+++ b/features/specific/wire_encoding.feature
@@ -1,0 +1,36 @@
+Feature: Wire Encoding Feature
+
+  This is just a simple feature meant to test
+  transmission of UTF-8 over the WireProtocol.
+
+  Scenario: Multibyte Character Step Matching
+    Given the following feature:
+      """
+      Feature: Match Regex With Multibyte Character String
+
+        Scenario: Match Regex
+          Given a step which uses regex to match the following text: 'カラオケ機' and 'ASCII'
+      """
+    And a step definition file with support code including:
+      """
+      #include <iostream>
+      #include <string>
+
+      GIVEN("a step which uses regex to match the following text: '(.+)' and '(.+)'") {
+        REGEX_PARAM(std::string, Match1);
+        REGEX_PARAM(std::string, Match2);
+        std::cout << Match1 << Match2 << std::endl;
+      }
+      """
+    When Cucumber runs the feature
+    Then the step output should contain:
+    # EXPECTED
+    #   """
+    #   カラオケ機ASCII
+    #   
+    #   """
+    # ACTUAL
+      """
+      \\u00E3\\u0082\\u00AB\\u00E3\\u0083\\u00A9\\u00E3\\u0082\\u00AA\\u00E3\\u0082\\u00B1\\u00E6\\u00A9\\u009FASCII
+
+      """

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,6 +1,8 @@
 #include <cucumber-cpp/internal/utils/Regex.hpp>
 #include <boost/make_shared.hpp>
 
+#include <algorithm>
+
 namespace cucumber {
 namespace internal {
 
@@ -24,7 +26,18 @@ boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
     return boost::make_shared<FindRegexMatch>(regexImpl, expression);
 }
 
-FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
+namespace {
+bool isUtf8CodeUnitStartOfCodepoint(unsigned int i) {
+    return (i & 0xc0) != 0x80;
+}
+
+std::ptrdiff_t utf8CodepointOffset(const std::string& expression,
+                                   const std::string::const_iterator& it) {
+    return count_if(expression.begin(), it, &isUtf8CodeUnitStartOfCodepoint);
+}
+} // namespace
+
+FindRegexMatch::FindRegexMatch(const boost::regex& regexImpl, const std::string& expression) {
     boost::smatch matchResults;
     regexMatched = boost::regex_search(
         expression, matchResults, regexImpl, boost::regex_constants::match_extra);
@@ -35,7 +48,7 @@ FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string 
             ++i;
         for (; i != matchResults.end(); ++i) {
             if (i->matched) {
-                RegexSubmatch s = {*i, i->first - expression.begin()};
+                RegexSubmatch s = {*i, utf8CodepointOffset(expression, i->first)};
                 submatches.push_back(s);
             } else {
                 submatches.push_back(RegexSubmatch());

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -3,6 +3,7 @@
 
 #include <json_spirit/json_spirit_reader_template.h>
 #include <json_spirit/json_spirit_writer_template.h>
+#include <json_spirit/json_spirit_writer_options.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
@@ -231,7 +232,7 @@ namespace {
             jsonOutput.clear();
             response.accept(*this);
             const mValue v(jsonOutput);
-            return write_string(v, false);
+            return write_string(v, ::raw_utf8);
         }
 
         void visit(const SuccessResponse& /*response*/) {

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -256,6 +256,52 @@ TEST_F(WireMessageCodecTest, handlesSnippetTextResponse) {
     EXPECT_THAT(codec.encode(response), StrEq("[\"success\",\"GIVEN(...)\"]"));
 }
 
+TEST_F(WireMessageCodecTest, encodesResponseUsingRawUtf8) {
+    std::vector<StepMatch> matches;
+    StepMatch sm1;
+    sm1.id = "1234";
+    sm1.regexp = "Some (.+) regexp (.+)";
+    StepMatchArg sm1arg1;
+    sm1arg1.value = "カラオケ機";
+    sm1arg1.position = 5;
+    sm1.args.push_back(sm1arg1);
+    StepMatchArg sm1arg2;
+    sm1arg2.value = "ASCII";
+    sm1arg2.position = 18;
+    sm1.args.push_back(sm1arg2);
+    matches.push_back(sm1);
+    StepMatchesResponse response(matches);
+
+    // clang-format off
+    // EXPECTED:
+    // EXPECT_THAT(codec.encode(response), StrEq(
+    //         "[\"success\",[{"
+    //             "\"args\":[{"
+    //                 "\"pos\":5,"
+    //                 "\"val\":\"カラオケ機\""
+    //             "},{"
+    //                 "\"pos\":18,"
+    //                 "\"val\":\"ASCII\""
+    //             "}],"
+    //             "\"id\":\"1234\","
+    //             "\"regexp\":\"Some (.+) regexp (.+)\""
+    //         "}]]"));
+    // ACTUAL:
+    EXPECT_THAT(codec.encode(response), StrEq(
+            "[\"success\",[{"
+                "\"args\":[{"
+                    "\"pos\":5,"
+                    "\"val\":\"\\u00E3\\u0082\\u00AB\\u00E3\\u0083\\u00A9\\u00E3\\u0082\\u00AA\\u00E3\\u0082\\u00B1\\u00E6\\u00A9\\u009F\""
+                "},{"
+                    "\"pos\":18,"
+                    "\"val\":\"ASCII\""
+                "}],"
+                "\"id\":\"1234\","
+                "\"regexp\":\"Some (.+) regexp (.+)\""
+            "}]]"));
+    // clang-format on
+}
+
 /*
  * Command response
  */

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -273,25 +273,11 @@ TEST_F(WireMessageCodecTest, encodesResponseUsingRawUtf8) {
     StepMatchesResponse response(matches);
 
     // clang-format off
-    // EXPECTED:
-    // EXPECT_THAT(codec.encode(response), StrEq(
-    //         "[\"success\",[{"
-    //             "\"args\":[{"
-    //                 "\"pos\":5,"
-    //                 "\"val\":\"カラオケ機\""
-    //             "},{"
-    //                 "\"pos\":18,"
-    //                 "\"val\":\"ASCII\""
-    //             "}],"
-    //             "\"id\":\"1234\","
-    //             "\"regexp\":\"Some (.+) regexp (.+)\""
-    //         "}]]"));
-    // ACTUAL:
     EXPECT_THAT(codec.encode(response), StrEq(
             "[\"success\",[{"
                 "\"args\":[{"
                     "\"pos\":5,"
-                    "\"val\":\"\\u00E3\\u0082\\u00AB\\u00E3\\u0083\\u00A9\\u00E3\\u0082\\u00AA\\u00E3\\u0082\\u00B1\\u00E6\\u00A9\\u009F\""
+                    "\"val\":\"カラオケ機\""
                 "},{"
                     "\"pos\":18,"
                     "\"val\":\"ASCII\""

--- a/tests/unit/RegexTest.cpp
+++ b/tests/unit/RegexTest.cpp
@@ -77,10 +77,7 @@ TEST(RegexTest, findReportsCodepointPositions) {
     EXPECT_TRUE(match->matches());
     ASSERT_EQ(2, match->getSubmatches().size());
     EXPECT_EQ(5, match->getSubmatches()[0].position);
-    // EXPECTED:
-    // EXPECT_EQ(18, match->getSubmatches()[1].position);
-    // ACTUAL
-    EXPECT_EQ(28, match->getSubmatches()[1].position);
+    EXPECT_EQ(18, match->getSubmatches()[1].position);
 }
 
 TEST(RegexTest, findAllExtractsTheFirstGroupOfEveryToken) {

--- a/tests/unit/RegexTest.cpp
+++ b/tests/unit/RegexTest.cpp
@@ -70,6 +70,19 @@ TEST(RegexTest, findAllDoesNotMatchIfNoTokens) {
     EXPECT_EQ(0, match->getSubmatches().size());
 }
 
+TEST(RegexTest, findReportsCodepointPositions) {
+    Regex twoArgs("Some (.+) regexp (.+)");
+    shared_ptr<RegexMatch> match(twoArgs.find("Some カラオケ機 regexp ASCII"));
+
+    EXPECT_TRUE(match->matches());
+    ASSERT_EQ(2, match->getSubmatches().size());
+    EXPECT_EQ(5, match->getSubmatches()[0].position);
+    // EXPECTED:
+    // EXPECT_EQ(18, match->getSubmatches()[1].position);
+    // ACTUAL
+    EXPECT_EQ(28, match->getSubmatches()[1].position);
+}
+
 TEST(RegexTest, findAllExtractsTheFirstGroupOfEveryToken) {
     Regex sum("([^,]+)(?:,|$)");
     shared_ptr<RegexMatch> match(sum.findAll("a,b,cc"));

--- a/travis.sh
+++ b/travis.sh
@@ -40,7 +40,7 @@ if [ -n "${FORMAT:-}" ]; then
     fi
     git clang-format-3.8 --binary=/usr/bin/clang-format-3.8 --style=file --commit="${BASE_HEAD}"
     # Assert that all changes adhere to the asked for style
-    exec git diff --exit-code
+    exec git diff --exit-code -- . ":!3rdparty"
 fi
 
 CTEST_OUTPUT_ON_FAILURE=ON


### PR DESCRIPTION
## Summary

This branch adds support for handling characters outside of the Unicode block 'Basic Latin' by updating `json-spirit` to the latest version and modifying `cucumber-cpp` to properly handle this change.

## Motivation and Context

This change adds support for passing raw UTF-8 strings from `cucumber-cpp` to `cucumber-ruby` which is necessary when writing tests which use non-'Basic Latin' characters to validate application behavior.

This relates to and resolves [#40](https://github.com/cucumber/cucumber-cpp/issues/40).

## How Has This Been Tested?

This branch adds three new tests ([5fff48f](https://github.com/cucumber/cucumber-cpp/commit/5fff48fac12d0fba74d173c426c672347ff47353)).

These tests were run following `cucumber-cpp`'s own instructions for building and testing.
* While commit [5fff48f](https://github.com/cucumber/cucumber-cpp/commit/5fff48fac12d0fba74d173c426c672347ff47353) is checked out, the tests, which demonstrate incorrect behavior, pass.
* Commit [581b3c8](https://github.com/cucumber/cucumber-cpp/commit/581b3c82e40fa369910dc025c814ab29db33b5d4) updates the `WireProtocolTest` in addition to modifying the `WireResponseEncoder::encode`. The modified test, demonstrating correct behavior, passes.
* Commit [1c0a1bd](https://github.com/cucumber/cucumber-cpp/commit/1c0a1bdf6097dc95970fc2afd490699c6ae7d7f5) modifies the other two tests to demonstrate the corrected RegEx match results.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
