### PR TITLE
Fix compilation with Boost 1.70.0

### DIFF
--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -51,7 +51,7 @@ public:
     void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
 #if BOOST_VERSION >= 107000
-    void log_build_info( std::ostream&, bool /*log_build_info*/) {};
+    void log_build_info(std::ostream&, bool /*log_build_info*/){};
 #else
     void log_build_info( std::ostream&) {};
 #endif

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -50,7 +50,11 @@ public:
     // Formatter
     void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
+#if BOOST_VERSION >= 107000
+    void log_build_info( std::ostream&, bool /*log_build_info*/) {};
+#else
     void log_build_info( std::ostream&) {};
+#endif
 
     void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
     void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

I have fixed a build error when using Boost 1.70.0.

## Details

<!--- Describe your changes in detail -->

I have added one missing parameter in log_build_info() method overload.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I wanted to use Boost library version 1.70.0 but the compilation failed.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran your tests and all of them passed (110/110).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [ x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [ ] I have verified whether my change requires changes to the documentation
- [ x] My change either requires no documentation change or I've updated the documentation accordingly.
- [ ] My branch has been rebased to master, keeping only relevant commits.
