### PR TITLE
Fix API change in boost::unit_test::unit_test_log_formatter

### DIFF
--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -16,18 +16,16 @@ using ::boost::execution_exception;
 namespace cucumber {
 namespace internal {
 
-
 namespace {
 
-    test_case* testCase = 0;
-    boost::function<void()> currentTestBody;
+test_case* testCase = 0;
+boost::function<void()> currentTestBody;
 
-    void exec_test_body() {
-        if (currentTestBody) {
-            currentTestBody();
-        }
+void exec_test_body() {
+    if (currentTestBody) {
+        currentTestBody();
     }
-
+}
 
 bool boost_test_init() {
     testCase = BOOST_TEST_CASE(&exec_test_body);
@@ -37,10 +35,9 @@ bool boost_test_init() {
 }
 
 // Freed by Boost's unit test framework on exit
-static CukeBoostLogInterceptor *logInterceptor = 0;
+static CukeBoostLogInterceptor* logInterceptor = 0;
 
-}
-
+} // namespace
 
 class CukeBoostLogInterceptor : public ::boost::unit_test::unit_test_log_formatter {
 public:
@@ -48,29 +45,35 @@ public:
     void reset();
 
     // Formatter
-    void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
-    void log_finish( std::ostream&) {};
-    void log_build_info( std::ostream&) {};
+    void log_start(std::ostream&, counter_t /*test_cases_amount*/){};
+    void log_finish(std::ostream&){};
 
-    void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
-    void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};
-    void test_unit_skipped( std::ostream&, test_unit const& /*tu*/) {};
-
-    void log_exception_start( std::ostream&, log_checkpoint_data const&, execution_exception const&) {};
-    void log_exception_finish( std::ostream& ) {};
-
-    void log_entry_start( std::ostream&, log_entry_data const&, log_entry_types /*let*/) {};
-    void log_entry_value( std::ostream&, const_string value);
-    void log_entry_value( std::ostream&, lazy_ostream const& value);
-    void log_entry_finish( std::ostream&) {};
-
-    void entry_context_start( std::ostream&, log_level /*l*/) {}
-#if BOOST_VERSION >= 106500
-    void log_entry_context( std::ostream&, log_level /*l*/, const_string /*value*/) {}
-    void entry_context_finish( std::ostream&, log_level /*l*/ ) {}
+#if BOOST_VERSION >= 107000
+    void log_build_info(std::ostream&, bool) {}
 #else
-    void log_entry_context( std::ostream&, const_string /*value*/) {}
-    void entry_context_finish( std::ostream& ) {}
+    void log_build_info(std::ostream&){};
+#endif
+
+    void test_unit_start(std::ostream&, test_unit const& /*tu*/){};
+    void test_unit_finish(std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/){};
+    void test_unit_skipped(std::ostream&, test_unit const& /*tu*/){};
+
+    void
+    log_exception_start(std::ostream&, log_checkpoint_data const&, execution_exception const&){};
+    void log_exception_finish(std::ostream&){};
+
+    void log_entry_start(std::ostream&, log_entry_data const&, log_entry_types /*let*/){};
+    void log_entry_value(std::ostream&, const_string value);
+    void log_entry_value(std::ostream&, lazy_ostream const& value);
+    void log_entry_finish(std::ostream&){};
+
+    void entry_context_start(std::ostream&, log_level /*l*/) {}
+#if BOOST_VERSION >= 106500
+    void log_entry_context(std::ostream&, log_level /*l*/, const_string /*value*/) {}
+    void entry_context_finish(std::ostream&, log_level /*l*/) {}
+#else
+    void log_entry_context(std::ostream&, const_string /*value*/) {}
+    void entry_context_finish(std::ostream&) {}
 #endif
 
 private:
@@ -113,12 +116,12 @@ const InvokeResult BoostStep::invokeStepBody() {
 void BoostStep::initBoostTest() {
     int argc = 1;
     char dummyArg[] = "dummy";
-    char *argv[] = { dummyArg };
+    char* argv[] = {dummyArg};
     framework::init(&boost_test_init, argc, argv);
 #if BOOST_VERSION >= 105900
     framework::finalize_setup_phase();
 #endif
-    
+
     logInterceptor = new CukeBoostLogInterceptor;
     ::boost::unit_test::unit_test_log.set_formatter(logInterceptor);
     ::boost::unit_test::unit_test_log.set_threshold_level(log_all_errors);
@@ -126,11 +129,11 @@ void BoostStep::initBoostTest() {
 
 void BoostStep::runWithMasterSuite() {
     currentTestBody = boost::bind(&BoostStep::body, this);
-    
+
     ::boost::unit_test::framework::run(testCase, false);
 
     currentTestBody.clear();
 }
 
-}
-}
+} // namespace internal
+} // namespace cucumber


### PR DESCRIPTION
## Summary
There is an API change in `unit_test_log_formatter` from Boost.Test.
## Details

`boost::unit_test::unit_test_log_formatter::log_build_info` now expects a second argument.

## Motivation and Context

There is now a preprocessor define to support building also with Boost.Test from 1.70.

## How Has This Been Tested?

Manual build with Boost 1.71. There's no package for Boost >= for trusty (as used on travis).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
