### PR TITLE
Supress waring about deprecated QSignalMapper

### DIFF
--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -2,6 +2,7 @@ project(CalcQt)
 
 if(TARGET Qt::Core AND TARGET Qt::Gui AND TARGET Qt::Widgets AND TARGET Qt::Test)
     add_library(libcalcqt STATIC src/CalculatorWidget.cpp src/CalculatorWidget.h)
+    target_compile_options(libcalcqt PRIVATE "-Wno-deprecated-declarations")
     set_target_properties(libcalcqt PROPERTIES AUTOMOC ON)
     target_include_directories(libcalcqt INTERFACE src)
     target_link_libraries(libcalcqt


### PR DESCRIPTION
## Summary

Suppress warnings about using QSignalMapper which is deprecated in Qt5.

## Details

Deprecation warnings are disabled in the Qt example project.

## Motivation and Context

The example project doesn't build when the warnings are enabled.

## How Has This Been Tested?

Travis builds with Qt 5 on macOS.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
