### PR TITLE
Compability with libc: remove -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ option_depr        (VALGRIND_TESTS            CUKE_TESTS_VALGRIND)
 #
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Werror -Wall -Wextra ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra ${CMAKE_CXX_FLAGS}")
     # TODO: A better fix should handle ld's --as-needed flag
     if(UNIX AND NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")


### PR DESCRIPTION
## Summary

Compiling cucumber-cpp using Alpine (libc) produces warnings about Boost using wrong imports.

`/include/sys/poll.h:1:2: error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Werror=cpp]`

I propose to drop -Werror or otherwise cucumber-cpp will not compile on platforms without glibc.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]  Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).