### PR TITLE
Fixed compile error when building with boost >= 1.70.

### DIFF
--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -50,8 +50,11 @@ public:
     // Formatter
     void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
+#if BOOST_VERSION >= 107000
+    void log_build_info( std::ostream&, bool = true) {};
+#else
     void log_build_info( std::ostream&) {};
-
+#endif
     void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
     void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};
     void test_unit_skipped( std::ostream&, test_unit const& /*tu*/) {};
@@ -72,6 +75,7 @@ public:
     void log_entry_context( std::ostream&, const_string /*value*/) {}
     void entry_context_finish( std::ostream& ) {}
 #endif
+
 
 private:
     std::stringstream description;


### PR DESCRIPTION
## Summary
Compiling BoostDriver.cpp fails because the signature of `unit_test_log_formatter::log_build_info` in `boost/test/unit_test_log_formatter.hpp` changed in boost version 1.70.

## Details
Compiling BoostDriver.cpp with boost version 1.71 fails with:
```
/cucumber-cpp/src/drivers/BoostDriver.cpp: In static member function ‘static void cucumber::internal::BoostStep::initBoostTest()’:
/cucumber-cpp/src/drivers/BoostDriver.cpp:122:26: error: invalid new-expression of abstract class type ‘cucumber::internal::CukeBoostLogInterceptor’
  122 |     logInterceptor = new CukeBoostLogInterceptor;
      |                          ^~~~~~~~~~~~~~~~~~~~~~~
/cucumber-cpp/src/drivers/BoostDriver.cpp:45:7: note:   because the following virtual functions are pure within ‘cucumber::internal::CukeBoostLogInterceptor’:
   45 | class CukeBoostLogInterceptor : public ::boost::unit_test::unit_test_log_formatter {
      |       ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /cucumber-cpp/src/drivers/BoostDriver.cpp:9:
/usr/include/boost/test/unit_test_log_formatter.hpp:144:25: note: 	‘virtual void boost::unit_test::unit_test_log_formatter::log_build_info(std::ostream&, bool)’
  144 |     virtual void        log_build_info( std::ostream& os, bool log_build_info = true ) = 0;
```