### PR TITLE
Add support for pkg-config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,3 +130,20 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
     FILE        CucumberCppConfig.cmake
 )
+
+configure_file(
+    "${PROJECT_SOURCE_DIR}/cmake/cucumber-cpp.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp.pc"
+    @ONLY
+)
+configure_file(
+    "${PROJECT_SOURCE_DIR}/cmake/cucumber-cpp-nomain.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp-nomain.pc"
+    @ONLY
+)
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp.pc"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp-nomain.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,12 +132,12 @@ install(
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/cmake/cucumber-cpp.pc.in"
+    "${PROJECT_SOURCE_DIR}/src/cmake/cucumber-cpp.pc.in"
     "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp.pc"
     @ONLY
 )
 configure_file(
-    "${PROJECT_SOURCE_DIR}/cmake/cucumber-cpp-nomain.pc.in"
+    "${PROJECT_SOURCE_DIR}/src/cmake/cucumber-cpp-nomain.pc.in"
     "${CMAKE_CURRENT_BINARY_DIR}/generated/cucumber-cpp-nomain.pc"
     @ONLY
 )

--- a/src/cmake/cucumber-cpp-nomain.pc.in
+++ b/src/cmake/cucumber-cpp-nomain.pc.in
@@ -3,7 +3,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: cucumber-cpp-nomain
 Description: Cucumber C++ (without main() function)
-Version: @PROJECT_VERSION@
+Version: 0.6
 URL: https://github.com/cucumber/cucumber-cpp
 Libs: -L${libdir} -lcucumber-cpp-nomain @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir}

--- a/src/cmake/cucumber-cpp-nomain.pc.in
+++ b/src/cmake/cucumber-cpp-nomain.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: cucumber-cpp-nomain
+Description: Cucumber C++ (without main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/cucumber/cucumber-cpp
+Libs: -L${libdir} -lcucumber-cpp-nomain @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir}

--- a/src/cmake/cucumber-cpp.pc.in
+++ b/src/cmake/cucumber-cpp.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: cucumber-cpp
+Description: Cucumber C++ (with main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/cucumber/cucumber-cpp
+Libs: -L${libdir} -lcucumber-cpp @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir}

--- a/src/cmake/cucumber-cpp.pc.in
+++ b/src/cmake/cucumber-cpp.pc.in
@@ -3,7 +3,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: cucumber-cpp
 Description: Cucumber C++ (with main() function)
-Version: @PROJECT_VERSION@
+Version: 0.6
 URL: https://github.com/cucumber/cucumber-cpp
 Libs: -L${libdir} -lcucumber-cpp @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir}


### PR DESCRIPTION
## Summary

Adds support for pkg-config.

## Details

Generates and installs `cucumber-cpp.pc` and `cucumber-cpp-nomain.pc` files.  The version number is hard-coded at 0.6 (one minor past the last tagged version) in the `.pc` files since there doesn't appear to be a version variable to use.

The implementation was largely lifted from Googletest.

## Motivation and Context

This was added to ease integration with other build systems (specifically, to be usable by flatpak + meson.)

## How Has This Been Tested?

As part of the build there are no unit tests, but the change was tested manually.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
