### PR TITLE
Fix boost 1.7x compatibility (fix #238)

### DIFF
--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -50,8 +50,11 @@ public:
     // Formatter
     void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
+#if BOOST_VERSION >= 107000
     void log_build_info( std::ostream&, bool /*log_build_info*/) {};
-
+#else
+    void log_build_info( std::ostream&) {};
+#endif
     void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
     void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};
     void test_unit_skipped( std::ostream&, test_unit const& /*tu*/) {};

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -50,7 +50,7 @@ public:
     // Formatter
     void log_start( std::ostream&, counter_t /*test_cases_amount*/) {};
     void log_finish( std::ostream&) {};
-    void log_build_info( std::ostream&) {};
+    void log_build_info( std::ostream&, bool /*log_build_info*/) {};
 
     void test_unit_start( std::ostream&, test_unit const& /*tu*/) {};
     void test_unit_finish( std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/) {};


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Boost 1.7x introduced changes to log_build_info method in the reporter class, which broke Cucumber-cpp.

## Details

Add the missing bool parameter to the log_build_info method

## Motivation and Context

To keep track with Boost releases.

## How Has This Been Tested?

This problem caused Cucumber-cpp to fail to build when configured with CUKE_ENABLE_BOOST_TEST=on.  
- [x] `make --build build --target install`
- [x] Tested with local project

Tested with make --build against Boost 1.74

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [X] I have verified whether my change requires changes to the documentation
  *NB: The README could be updated to say which is the latest Boost version that is tested as compatible
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
