### PR TITLE
Enable compiling with clang's -Wsuggest-override

### DIFF
--- a/include/cucumber-cpp/internal/RegistrationMacros.hpp
+++ b/include/cucumber-cpp/internal/RegistrationMacros.hpp
@@ -1,6 +1,12 @@
 #ifndef CUKE_REGISTRATIONMACROS_HPP_
 #define CUKE_REGISTRATIONMACROS_HPP_
 
+#if __cplusplus >= 201103L
+#define CUKE_OVERRIDE override
+#else
+#define CUKE_OVERRIDE
+#endif
+
 // ************************************************************************** //
 // **************            OBJECT NAMING MACROS              ************** //
 // ************************************************************************** //
@@ -24,7 +30,7 @@
 #define CUKE_OBJECT_(class_name, parent_class, registration_fn, args)     \
 class class_name : public parent_class {                                  \
 public:                                                                   \
-    void body() {                                                         \
+    void body() CUKE_OVERRIDE {                                           \
         return invokeWithArgs(*this, &class_name::bodyWithArgs);          \
     }                                                                     \
     void bodyWithArgs args;                                               \


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

When compiling step definitions with clang's `-Wsuggest-override`, clang
warns about every step definition because  the expanded `body()` from
the macro overrides a virtual function, but isn't marked `override`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code. 
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
