### PR TITLE
Add posibility to build with sanitizers enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ option(CUKE_ENABLE_GTEST        "Enable Google Test framework" ON)
 option(CUKE_ENABLE_QT           "Enable Qt framework" ON)
 option(CUKE_TESTS_E2E           "Enable end-to-end tests" ON)
 option(CUKE_TESTS_UNIT          "Enable unit tests" ON)
+set(CUKE_ENABLE_SANITIZER       "OFF" CACHE STRING "Sanitizer to use for checking")
+set_property(CACHE CUKE_ENABLE_SANITIZER PROPERTY STRINGS OFF "address" "thread" "undefined")
 option(CUKE_TESTS_VALGRIND      "Enable tests within Valgrind" OFF)
 set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise downloaded)")
 set(GMOCK_VER "1.7.0" CACHE STRING "Google Mock framework version to be used")
@@ -243,6 +245,25 @@ if(CUKE_ENABLE_QT)
         endif()
     endif()
 endif()
+
+
+#
+# Sanitizers
+#
+
+if(CUKE_ENABLE_SANITIZER AND NOT ${CUKE_ENABLE_SANITIZER} EQUAL "OFF")
+    message("Disabling valgrind when a sanitizer is enabled")
+    set(CUKE_TESTS_VALGRIND OFF)
+
+    if (WIN32)
+        message(WARNING "The use of the sanatizers on Windows is not tested")
+    endif()
+
+    add_compile_options("-fsanitize=${CUKE_ENABLE_SANITIZER}")
+    add_link_options("-fsanitize=${CUKE_ENABLE_SANITIZER}")
+endif()
+
+
 
 #
 # Valgrind


### PR DESCRIPTION
The sanitizers 'address', 'thread', and 'undefined behaviour' can
be activated.

This is a replacement for #229 

## Summary

Add the possibility to build with sanitizer support (address, thread, undefined).

## Motivation and Context

The sanitizers are usefull for finding leaks, race conditions or undefined behaviour.

## How Has This Been Tested?

Tested locally. They can be added to CI as soon as all found bugs are fixed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
