### PR TITLE
add file extensions to adhere to policy CMP0115

### DIFF
--- a/examples/Calc/CMakeLists.txt
+++ b/examples/Calc/CMakeLists.txt
@@ -1,15 +1,15 @@
 project(Calc)
 
-add_library(Calc STATIC src/Calculator)
+add_library(Calc STATIC src/Calculator.cpp)
 target_include_directories(Calc INTERFACE src)
 
 if(TARGET GTest::GTest)
-    add_executable(GTestCalculatorSteps features/step_definitions/GTestCalculatorSteps)
+    add_executable(GTestCalculatorSteps features/step_definitions/GTestCalculatorSteps.cpp)
     target_link_libraries(GTestCalculatorSteps PRIVATE Calc cucumber-cpp GTest::GTest)
 
     list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_variadic_templates HAS_VARIADIC_TEMPLATES)
     if(HAS_VARIADIC_TEMPLATES GREATER -1)
-        add_executable(FuncArgsCalculatorSteps features/step_definitions/FuncArgsCalculatorSteps)
+        add_executable(FuncArgsCalculatorSteps features/step_definitions/FuncArgsCalculatorSteps.cpp)
         target_link_libraries(FuncArgsCalculatorSteps PRIVATE Calc cucumber-cpp GTest::GTest)
 
         target_compile_features(FuncArgsCalculatorSteps PRIVATE cxx_variadic_templates)
@@ -17,11 +17,11 @@ if(TARGET GTest::GTest)
 endif()
 
 if(TARGET Boost::unit_test_framework)
-    add_executable(BoostCalculatorSteps features/step_definitions/BoostCalculatorSteps)
+    add_executable(BoostCalculatorSteps features/step_definitions/BoostCalculatorSteps.cpp)
     target_link_libraries(BoostCalculatorSteps PRIVATE Calc cucumber-cpp Boost::unit_test_framework)
 endif()
 
 if(TARGET Qt::Test)
-    add_executable(QtTestCalculatorSteps features/step_definitions/QtTestCalculatorSteps)
+    add_executable(QtTestCalculatorSteps features/step_definitions/QtTestCalculatorSteps.cpp)
     target_link_libraries(QtTestCalculatorSteps Calc Qt::Test cucumber-cpp)
 endif()

--- a/examples/CalcQt/CMakeLists.txt
+++ b/examples/CalcQt/CMakeLists.txt
@@ -16,7 +16,7 @@ if(TARGET Qt::Core AND TARGET Qt::Gui AND TARGET Qt::Widgets AND TARGET Qt::Test
     add_executable(calcqt src/CalcQt.cpp)
     target_link_libraries(calcqt PRIVATE libcalcqt Qt::Widgets)
 
-    add_executable(QtTestCalculatorQtSteps features/step_definitions/QtTestCalculatorQtSteps)
+    add_executable(QtTestCalculatorQtSteps features/step_definitions/QtTestCalculatorQtSteps.cpp)
     target_link_libraries(QtTestCalculatorQtSteps PRIVATE libcalcqt Qt::Test cucumber-cpp)
 
     if(TARGET Boost::unit_test_framework)
@@ -25,7 +25,7 @@ if(TARGET Qt::Core AND TARGET Qt::Gui AND TARGET Qt::Widgets AND TARGET Qt::Test
     endif()
 
     if(TARGET GTest::GTest)
-        add_executable(GTestCalculatorQtSteps features/step_definitions/GTestCalculatorQtSteps)
+        add_executable(GTestCalculatorQtSteps features/step_definitions/GTestCalculatorQtSteps.cpp)
         target_link_libraries(GTestCalculatorQtSteps PRIVATE libcalcqt cucumber-cpp GTest::GTest Qt::Test)
     endif()
 

--- a/examples/FeatureShowcase/CMakeLists.txt
+++ b/examples/FeatureShowcase/CMakeLists.txt
@@ -11,8 +11,8 @@ if(TARGET GTest::GTest)
     endfunction()
 
     add_cucumber_executable(
-        features/step_definitions/TagSteps
-        features/step_definitions/TableSteps
+        features/step_definitions/TagSteps.cpp
+        features/step_definitions/TableSteps.cpp
     )
 endif()
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Add file extensions to adhere to policy CMP0115. This was added with CMake 3.20.

## Details

## Motivation and Context

Removes warning when running CMake.

## How Has This Been Tested?

Run on Debian 9, 10 and 11.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [ ] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to master, keeping only relevant commits.
