### PR TITLE
fix references to main branch (from formerly master)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,4 @@
 - [ ] I've added tests for my code.
 - [ ] I have verified whether my change requires changes to the documentation
 - [ ] My change either requires no documentation change or I've updated the documentation accordingly.
-- [ ] My branch has been rebased to master, keeping only relevant commits.
+- [ ] My branch has been rebased to main, keeping only relevant commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
+Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/main/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## In Git
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ Before you can contribute, you have to be able to build the source and run tests
 
 The process for using git/github is similar to the [Github-Flow](http://scottchacon.com/2011/08/31/github-flow.html)
 
-* **Anything** in the master branch is good enough to release
+* **Anything** in the main branch is good enough to release
 * Working on nontrivial features
-    + Create a descriptively named branch off of master
+    + Create a descriptively named branch off of main
     + Commit to that branch locally and regularly
     + Push your work to the same named branch on the server
-    + Regularly rebase this branch from master to keep it up to date
+    + Regularly rebase this branch from main to keep it up to date
 * Open a pull request
     + When you need feedback or help
     + You think the branch is ready for merging (you can use the [hub](https://github.com/defunkt/hub#git-pull-request) command-line tool)
@@ -71,4 +71,4 @@ Here is an [Example](https://github.com/cucumber/bool/pull/12) of this process i
 - New development branch commit (e.g. [da60995](https://github.com/cucumber/cucumber-cpp/commit/da609956fcd42046e5182c6226acd7e53dd7754e)):
   - Add new "In Git" section to `CHANGELOG.md`
   - Commit with message `Preparing history file for next development release`
-- Push commits and tags to master
+- Push commits and tags to main

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ your question on the Cucumber discussion group instead, prefixing the title
 with [CPP].
 
 If you want to contribute code to the project, guidelines are in the
-[`CONTRIBUTING.md` file](https://github.com/cucumber/cucumber-cpp/blob/master/CONTRIBUTING.md).
+[`CONTRIBUTING.md` file](https://github.com/cucumber/cucumber-cpp/blob/main/CONTRIBUTING.md).
 
 It relies on a few executables:
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Some places still had the old name (master) for the main branch.

<!--- Provide a general summary description of your changes -->

## Details

Replacing instances of master with main.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Update documentation to actual code to keep it correct :)

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (documentation) (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
