### PR TITLE
Using C++ standard library where possible instead of boost

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,6 @@ BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Attach
 ColumnLimit:     100
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ForEachMacros:   [ BOOST_FOREACH ]
 IncludeCategories: 
   # The autodetect header should always be included last
   - Regex:           '^<cucumber-cpp/autodetect\.hpp>$'

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -22,13 +22,11 @@ jobs:
         g++ \
         gcovr \
         git \
-        libboost-date-time-dev \
         libboost-filesystem-dev \
         libboost-program-options-dev \
         libboost-regex-dev \
         libboost-system-dev \
         libboost-test-dev \
-        libboost-thread-dev \
         make \
         ninja-build \
         qtbase5-dev \

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -22,7 +22,6 @@ jobs:
         g++ \
         gcovr \
         git \
-        libboost-filesystem-dev \
         libboost-program-options-dev \
         libboost-regex-dev \
         libboost-system-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ else()
 endif()
 
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(CUKE_CORE_BOOST_LIBS thread system regex date_time program_options filesystem)
+set(CUKE_CORE_BOOST_LIBS system regex program_options filesystem)
 if(CUKE_ENABLE_BOOST_TEST)
     # "An external test runner utility is required to link with dynamic library" (Boost User's Guide)
     set(Boost_USE_STATIC_LIBS OFF)
@@ -151,14 +151,6 @@ if(Boost_INCLUDE_DIRS AND NOT TARGET Boost::boost)
     set_target_properties(Boost::boost PROPERTIES
         "INTERFACE_INCLUDE_DIRECTORIES" "${Boost_INCLUDE_DIRS}")
 endif()
-if(Boost_THREAD_LIBRARY AND NOT TARGET Boost::thread)
-    find_package(Threads REQUIRED)
-    add_library(Boost::thread ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::thread PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_THREAD_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Threads::Threads;Boost::boost"
-    )
-endif()
 if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
     add_library(Boost::system ${LIBRARY_TYPE} IMPORTED)
     set_target_properties(Boost::system PROPERTIES
@@ -182,13 +174,6 @@ if(Boost_REGEX_LIBRARY AND NOT TARGET Boost::regex)
     add_library(Boost::regex ${LIBRARY_TYPE} IMPORTED)
     set_target_properties(Boost::regex PROPERTIES
         "IMPORTED_LOCATION" "${Boost_REGEX_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::boost"
-    )
-endif()
-if(Boost_DATE_TIME_LIBRARY AND NOT TARGET Boost::date_time)
-    add_library(Boost::date_time ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::date_time PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_DATE_TIME_LIBRARY}"
         "INTERFACE_LINK_LIBRARIES" "Boost::boost"
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,11 @@ set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise
 set(GMOCK_VER "1.11.0" CACHE STRING "Google Mock framework version to be used")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)
-elseif(CMAKE_CXX_STANDARD LESS 14)
-    message(FATAL_ERROR "C++14 (above) is required")
+elseif(CMAKE_CXX_STANDARD LESS 17)
+    message(FATAL_ERROR "C++17 (above) is required")
 endif()
 
 if(CUKE_CODE_COVERAGE)
@@ -122,7 +122,7 @@ else()
 endif()
 
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(CUKE_CORE_BOOST_LIBS system regex program_options filesystem)
+set(CUKE_CORE_BOOST_LIBS system regex program_options)
 if(CUKE_ENABLE_BOOST_TEST)
     # "An external test runner utility is required to link with dynamic library" (Boost User's Guide)
     set(Boost_USE_STATIC_LIBS OFF)
@@ -162,13 +162,6 @@ if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
             "COMPILE_DEFINITIONS" BOOST_ERROR_CODE_HEADER_ONLY=1
         )
     endif()
-endif()
-if(Boost_FILESYSTEM_LIBRARY AND NOT TARGET Boost::filesystem)
-    add_library(Boost::filesystem ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::filesystem PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_FILESYSTEM_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::system;Boost::boost"
-    )
 endif()
 if(Boost_REGEX_LIBRARY AND NOT TARGET Boost::regex)
     add_library(Boost::regex ${LIBRARY_TYPE} IMPORTED)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It relies on a few executables:
 It relies on a few libraries:
 
 * [Boost](http://www.boost.org/) 1.46 or later (1.51+ on Windows).
-  Required libraries: *thread*, *system*, *regex*, *date_time* and *program_options*.
+  Required libraries: *system*, *regex* and *program_options*.
   Optional library for Boost Test driver: *test*.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.
   Optional for the GTest driver. By default downloaded and built by CMake.

--- a/include/cucumber-cpp/internal/ContextManager.hpp
+++ b/include/cucumber-cpp/internal/ContextManager.hpp
@@ -5,30 +5,28 @@
 
 #include <vector>
 
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 namespace cucumber {
 
 namespace internal {
 
-typedef std::vector<boost::shared_ptr<void> > contexts_type;
+typedef std::vector<std::shared_ptr<void> > contexts_type;
 
 class CUCUMBER_CPP_EXPORT ContextManager {
 public:
     void purgeContexts();
-    template<class T> boost::weak_ptr<T> addContext();
+    template<class T> std::weak_ptr<T> addContext();
 
 protected:
     static contexts_type contexts;
 };
 
 template<class T>
-boost::weak_ptr<T> ContextManager::addContext() {
-    boost::shared_ptr<T> shared(boost::make_shared<T>());
+std::weak_ptr<T> ContextManager::addContext() {
+    std::shared_ptr<T> shared(std::make_shared<T>());
     contexts.push_back(shared);
-    return boost::weak_ptr<T> (shared);
+    return std::weak_ptr<T> (shared);
 }
 
 }
@@ -44,12 +42,12 @@ public:
 
 private:
     internal::ContextManager contextManager;
-    boost::shared_ptr<T> context;
-    static boost::weak_ptr<T> contextReference;
+    std::shared_ptr<T> context;
+    static std::weak_ptr<T> contextReference;
 };
 
 template<class T>
-boost::weak_ptr<T> ScenarioScope<T>::contextReference;
+std::weak_ptr<T> ScenarioScope<T>::contextReference;
 
 template<class T>
 ScenarioScope<T>::ScenarioScope() {

--- a/include/cucumber-cpp/internal/CukeCommands.hpp
+++ b/include/cucumber-cpp/internal/CukeCommands.hpp
@@ -11,12 +11,10 @@
 #include <string>
 #include <sstream>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace cucumber {
 namespace internal {
-
-using boost::shared_ptr;
 
 /**
  * Legacy class to be removed when feature #31 is complete, substituted by CukeEngineImpl.
@@ -41,7 +39,7 @@ private:
     bool hasStarted;
 
 private:
-    static shared_ptr<Scenario> currentScenario;
+    static std::shared_ptr<Scenario> currentScenario;
 };
 
 }

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -5,7 +5,7 @@
 #include "ProtocolHandler.hpp"
 #include "../../CukeEngine.hpp"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace cucumber {
 namespace internal {
@@ -102,7 +102,7 @@ public:
      *
      * @return The command response (ownership passed to the caller)
      */
-    virtual boost::shared_ptr<WireResponse> run(CukeEngine& engine) const = 0;
+    virtual std::shared_ptr<WireResponse> run(CukeEngine& engine) const = 0;
 
     virtual ~WireCommand() {};
 };
@@ -136,7 +136,7 @@ public:
      *
      * @throws WireMessageCodecException
      */
-    virtual boost::shared_ptr<WireCommand> decode(const std::string &request) const = 0;
+    virtual std::shared_ptr<WireCommand> decode(const std::string &request) const = 0;
 
     /**
      * Encodes a response to wire format.
@@ -156,7 +156,7 @@ public:
 class CUCUMBER_CPP_EXPORT JsonSpiritWireMessageCodec : public WireMessageCodec {
 public:
     JsonSpiritWireMessageCodec();
-    boost::shared_ptr<WireCommand> decode(const std::string &request) const;
+    std::shared_ptr<WireCommand> decode(const std::string &request) const;
     const std::string encode(const WireResponse& response) const;
 };
 

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp
@@ -2,7 +2,7 @@
 #define CUKE_WIREPROTOCOL_COMMANDS_HPP_
 
 #include "WireProtocol.hpp"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace cucumber {
 namespace internal {
@@ -19,7 +19,7 @@ class BeginScenarioCommand : public ScenarioCommand {
 public:
     BeginScenarioCommand(const CukeEngine::tags_type& tags);
 
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -27,7 +27,7 @@ class EndScenarioCommand : public ScenarioCommand {
 public:
     EndScenarioCommand(const CukeEngine::tags_type& tags);
 
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -38,7 +38,7 @@ private:
 public:
     StepMatchesCommand(const std::string & stepName);
 
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -53,7 +53,7 @@ public:
                   const CukeEngine::invoke_args_type& args,
                   const CukeEngine::invoke_table_type& tableArg);
 
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
@@ -66,13 +66,13 @@ public:
                        const std::string & name,
                        const std::string & multilineArgClass);
 
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 
 class FailingCommand : public WireCommand {
 public:
-    boost::shared_ptr<WireResponse> run(CukeEngine& engine) const;
+    std::shared_ptr<WireResponse> run(CukeEngine& engine) const;
 };
 
 }

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -7,8 +7,7 @@
 #include "../step/StepManager.hpp"
 
 #include <boost/config.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <list>
 
@@ -64,25 +63,25 @@ class CUCUMBER_CPP_EXPORT AfterAllHook : public UnconditionalHook {};
 
 class CUCUMBER_CPP_EXPORT HookRegistrar {
 public:
-    typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
-    typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
+    typedef std::list< std::shared_ptr<Hook> > hook_list_type;
+    typedef std::list< std::shared_ptr<AroundStepHook> > aroundhook_list_type;
 
-    static void addBeforeHook(boost::shared_ptr<BeforeHook> afterHook);
+    static void addBeforeHook(std::shared_ptr<BeforeHook> afterHook);
     static void execBeforeHooks(Scenario *scenario);
 
-    static void addAroundStepHook(boost::shared_ptr<AroundStepHook> aroundStepHook);
+    static void addAroundStepHook(std::shared_ptr<AroundStepHook> aroundStepHook);
     static InvokeResult execStepChain(Scenario *scenario, const StepInfo* stepInfo, const InvokeArgs *pArgs);
 
-    static void addAfterStepHook(boost::shared_ptr<AfterStepHook> afterStepHook);
+    static void addAfterStepHook(std::shared_ptr<AfterStepHook> afterStepHook);
     static void execAfterStepHooks(Scenario *scenario);
 
-    static void addAfterHook(boost::shared_ptr<AfterHook> afterHook);
+    static void addAfterHook(std::shared_ptr<AfterHook> afterHook);
     static void execAfterHooks(Scenario *scenario);
 
-    static void addBeforeAllHook(boost::shared_ptr<BeforeAllHook> beforeAllHook);
+    static void addBeforeAllHook(std::shared_ptr<BeforeAllHook> beforeAllHook);
     static void execBeforeAllHooks();
 
-    static void addAfterAllHook(boost::shared_ptr<AfterAllHook> afterAllHook);
+    static void addAfterAllHook(std::shared_ptr<AfterAllHook> afterAllHook);
     static void execAfterAllHooks();
 
 private:
@@ -133,7 +132,7 @@ private:
 
 template<class T>
 static int registerBeforeHook(const std::string &csvTagNotation) {
-   boost::shared_ptr<T> hook(boost::make_shared<T>());
+   std::shared_ptr<T> hook(std::make_shared<T>());
    hook->setTags(csvTagNotation);
    HookRegistrar::addBeforeHook(hook);
    return 0; // We are not interested in the ID at this time
@@ -141,7 +140,7 @@ static int registerBeforeHook(const std::string &csvTagNotation) {
 
 template<class T>
 static int registerAroundStepHook(const std::string &csvTagNotation) {
-   boost::shared_ptr<T> hook(boost::make_shared<T>());
+   std::shared_ptr<T> hook(std::make_shared<T>());
    hook->setTags(csvTagNotation);
    HookRegistrar::addAroundStepHook(hook);
    return 0;
@@ -149,7 +148,7 @@ static int registerAroundStepHook(const std::string &csvTagNotation) {
 
 template<class T>
 static int registerAfterStepHook(const std::string &csvTagNotation) {
-   boost::shared_ptr<T> hook(boost::make_shared<T>());
+   std::shared_ptr<T> hook(std::make_shared<T>());
    hook->setTags(csvTagNotation);
    HookRegistrar::addAfterStepHook(hook);
    return 0;
@@ -157,7 +156,7 @@ static int registerAfterStepHook(const std::string &csvTagNotation) {
 
 template<class T>
 static int registerAfterHook(const std::string &csvTagNotation) {
-   boost::shared_ptr<T> hook(boost::make_shared<T>());
+   std::shared_ptr<T> hook(std::make_shared<T>());
    hook->setTags(csvTagNotation);
    HookRegistrar::addAfterHook(hook);
    return 0;
@@ -165,13 +164,13 @@ static int registerAfterHook(const std::string &csvTagNotation) {
 
 template<class T>
 static int registerBeforeAllHook() {
-   HookRegistrar::addBeforeAllHook(boost::make_shared<T>());
+   HookRegistrar::addBeforeAllHook(std::make_shared<T>());
    return 0;
 }
 
 template<class T>
 static int registerAfterAllHook() {
-   HookRegistrar::addAfterAllHook(boost::make_shared<T>());
+   HookRegistrar::addAfterAllHook(std::make_shared<T>());
    return 0;
 }
 

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -8,9 +8,7 @@
 #include <vector>
 
 #include <boost/config.hpp>
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #ifndef BOOST_NO_VARIADIC_TEMPLATES
     #include <type_traits>
@@ -34,7 +32,7 @@ public:
 
     operator const void *() const;
 
-    boost::shared_ptr<const StepInfo> stepInfo;
+    std::shared_ptr<const StepInfo> stepInfo;
     submatches_type submatches;
 };
 
@@ -99,7 +97,7 @@ public:
     const std::string &getDescription() const;
 };
 
-class CUCUMBER_CPP_EXPORT StepInfo : public boost::enable_shared_from_this<StepInfo> {
+class CUCUMBER_CPP_EXPORT StepInfo : public std::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
 
@@ -178,10 +176,10 @@ public:
 
 class CUCUMBER_CPP_EXPORT StepManager {
 protected:
-    typedef std::map<step_id_type, boost::shared_ptr<const StepInfo> > steps_type;
+    typedef std::map<step_id_type, std::shared_ptr<const StepInfo> > steps_type;
 
 public:
-    static step_id_type addStep(boost::shared_ptr<StepInfo> stepInfo);
+    static step_id_type addStep(std::shared_ptr<StepInfo> stepInfo);
     static MatchResult stepMatches(const std::string &stepDescription);
     static const StepInfo* getStep(step_id_type id);
 protected:
@@ -213,7 +211,7 @@ static inline std::string toSourceString(const char *filePath, const int line) {
 
 template<class T>
 static int registerStep(const std::string &stepMatcher, const char *file, const int line) {
-   return StepManager::addStep(boost::make_shared< StepInvoker<T> >(stepMatcher, toSourceString(file, line)));
+   return StepManager::addStep(std::make_shared< StepInvoker<T> >(stepMatcher, toSourceString(file, line)));
 }
 
 template<typename T>

--- a/include/cucumber-cpp/internal/utils/Regex.hpp
+++ b/include/cucumber-cpp/internal/utils/Regex.hpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
 
 namespace cucumber {
@@ -48,8 +47,8 @@ private:
 public:
     Regex(std::string expr);
 
-    boost::shared_ptr<RegexMatch> find(const std::string &expression) const;
-    boost::shared_ptr<RegexMatch> findAll(const std::string &expression) const;
+    std::shared_ptr<RegexMatch> find(const std::string &expression) const;
+    std::shared_ptr<RegexMatch> findAll(const std::string &expression) const;
 
     std::string str() const;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,6 @@ foreach(TARGET
             Boost::boost
             Boost::regex
         PRIVATE
-            Boost::filesystem
             ${CUKE_EXTRA_PRIVATE_LIBRARIES}
     )
     # Don't export or import symbols for statically linked libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,9 +85,7 @@ foreach(TARGET
             Boost::boost
             Boost::regex
         PRIVATE
-            Boost::date_time
             Boost::filesystem
-            Boost::thread
             ${CUKE_EXTRA_PRIVATE_LIBRARIES}
     )
     # Don't export or import symbols for statically linked libraries

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -3,12 +3,11 @@
 
 #include <sstream>
 #include <boost/algorithm/string.hpp>
-#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
 
-shared_ptr<Scenario> CukeCommands::currentScenario;
+std::shared_ptr<Scenario> CukeCommands::currentScenario;
 
 CukeCommands::CukeCommands() : hasStarted(false) {
 }
@@ -25,7 +24,7 @@ void CukeCommands::beginScenario(const TagExpression::tag_list& tags) {
         HookRegistrar::execBeforeAllHooks();
     }
 
-    currentScenario = boost::make_shared<Scenario>(tags);
+    currentScenario = std::make_shared<Scenario>(tags);
     HookRegistrar::execBeforeHooks(currentScenario.get());
 }
 

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -2,7 +2,6 @@
 #include "cucumber-cpp/internal/hook/HookRegistrar.hpp"
 
 #include <sstream>
-#include <boost/algorithm/string.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -36,7 +35,9 @@ void CukeCommands::endScenario() {
 
 const std::string CukeCommands::snippetText(const std::string stepKeyword, const std::string stepName) const {
     std::stringstream text;
-    text << boost::to_upper_copy(stepKeyword)
+    std::string stepKeywordUpperCase;
+    std::transform(stepKeyword.begin(), stepKeyword.end(), std::back_inserter(stepKeywordUpperCase), ::toupper);
+    text << stepKeywordUpperCase
         << "(\""
         << escapeCString("^" + escapeRegex(stepName) + "$")
         << "\") {\n"

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -1,6 +1,5 @@
 #include "cucumber-cpp/internal/CukeEngineImpl.hpp"
 
-#include <boost/foreach.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -24,12 +23,12 @@ namespace {
 std::vector<StepMatch> CukeEngineImpl::stepMatches(const std::string & name) const {
     std::vector<StepMatch> engineResult;
     MatchResult commandResult = cukeCommands.stepMatches(name);
-    BOOST_FOREACH(const SingleStepMatch commandMatch, commandResult.getResultSet()) {
+    for(const SingleStepMatch & commandMatch : commandResult.getResultSet()) {
         StepMatch engineMatch;
         engineMatch.id = convertId(commandMatch.stepInfo->id);
         engineMatch.source = commandMatch.stepInfo->source;
         engineMatch.regexp = commandMatch.stepInfo->regex.str();
-        BOOST_FOREACH(const RegexSubmatch commandMatchArg, commandMatch.submatches) {
+        for(const RegexSubmatch & commandMatchArg : commandMatch.submatches) {
             StepMatchArg engineMatchArg;
             engineMatchArg.value = commandMatchArg.value;
             engineMatchArg.position = commandMatchArg.position;
@@ -49,7 +48,7 @@ void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type &
 
     InvokeArgs commandArgs;
     try {
-        BOOST_FOREACH(const std::string a, args) {
+        for(const std::string & a : args) {
             commandArgs.addArg(a);
         }
 

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -36,7 +36,7 @@ void UnconditionalHook::invokeHook(Scenario*, CallableStep *) {
     body();
 }
 
-void HookRegistrar::addBeforeHook(boost::shared_ptr<BeforeHook> beforeHook) {
+void HookRegistrar::addBeforeHook(std::shared_ptr<BeforeHook> beforeHook) {
     beforeHooks().push_back(beforeHook);
 }
 
@@ -50,7 +50,7 @@ void HookRegistrar::execBeforeHooks(Scenario *scenario) {
 }
 
 
-void HookRegistrar::addAroundStepHook(boost::shared_ptr<AroundStepHook> aroundStepHook) {
+void HookRegistrar::addAroundStepHook(std::shared_ptr<AroundStepHook> aroundStepHook) {
     aroundStepHooks().push_front(aroundStepHook);
 }
 
@@ -64,7 +64,7 @@ InvokeResult HookRegistrar::execStepChain(Scenario *scenario, const StepInfo* co
     return scc.exec();
 }
 
-void HookRegistrar::addAfterStepHook(boost::shared_ptr<AfterStepHook> afterStepHook) {
+void HookRegistrar::addAfterStepHook(std::shared_ptr<AfterStepHook> afterStepHook) {
     afterStepHooks().push_front(afterStepHook);
 }
 
@@ -78,7 +78,7 @@ void HookRegistrar::execAfterStepHooks(Scenario *scenario) {
 }
 
 
-void HookRegistrar::addAfterHook(boost::shared_ptr<AfterHook> afterHook) {
+void HookRegistrar::addAfterHook(std::shared_ptr<AfterHook> afterHook) {
     afterHooks().push_front(afterHook);
 }
 
@@ -103,7 +103,7 @@ HookRegistrar::hook_list_type& HookRegistrar::beforeAllHooks() {
     return beforeAllHooks;
 }
 
-void HookRegistrar::addBeforeAllHook(boost::shared_ptr<BeforeAllHook> beforeAllHook) {
+void HookRegistrar::addBeforeAllHook(std::shared_ptr<BeforeAllHook> beforeAllHook) {
     beforeAllHooks().push_back(beforeAllHook);
 }
 
@@ -116,7 +116,7 @@ HookRegistrar::hook_list_type& HookRegistrar::afterAllHooks() {
     return afterAllHooks;
 }
 
-void HookRegistrar::addAfterAllHook(boost::shared_ptr<AfterAllHook> afterAllHook) {
+void HookRegistrar::addAfterAllHook(std::shared_ptr<AfterAllHook> afterAllHook) {
     afterAllHooks().push_back(afterAllHook);
 }
 

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,5 +1,4 @@
 #include <cucumber-cpp/internal/utils/Regex.hpp>
-#include <boost/make_shared.hpp>
 
 #include <algorithm>
 
@@ -22,8 +21,8 @@ std::string Regex::str() const {
     return regexImpl.str();
 }
 
-boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
-    return boost::make_shared<FindRegexMatch>(regexImpl, expression);
+std::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
+    return std::make_shared<FindRegexMatch>(regexImpl, expression);
 }
 
 namespace {
@@ -57,8 +56,8 @@ FindRegexMatch::FindRegexMatch(const boost::regex& regexImpl, const std::string&
     }
 }
 
-boost::shared_ptr<RegexMatch> Regex::findAll(const std::string &expression) const {
-    return boost::make_shared<FindAllRegexMatch>(regexImpl, expression);
+std::shared_ptr<RegexMatch> Regex::findAll(const std::string &expression) const {
+    return std::make_shared<FindAllRegexMatch>(regexImpl, expression);
 }
 
 FindAllRegexMatch::FindAllRegexMatch(const boost::regex &regexImpl, const std::string &expression) {

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -13,7 +13,7 @@ StepInfo::StepInfo(const std::string &stepMatcher, const std::string source) :
 
 SingleStepMatch StepInfo::matches(const std::string &stepDescription) const {
     SingleStepMatch stepMatch;
-    boost::shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
+    std::shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
     if (regexMatch->matches()) {
         stepMatch.stepInfo = shared_from_this();
         stepMatch.submatches = regexMatch->getSubmatches();
@@ -104,14 +104,14 @@ const std::string &InvokeResult::getDescription() const {
 }
 
 
-step_id_type StepManager::addStep(boost::shared_ptr<StepInfo> stepInfo) {
+step_id_type StepManager::addStep(std::shared_ptr<StepInfo> stepInfo) {
     return steps().insert(std::make_pair(stepInfo->id, stepInfo)).first->first;
 }
 
 MatchResult StepManager::stepMatches(const std::string &stepDescription) {
     MatchResult matchResult;
     for (steps_type::iterator iter = steps().begin(); iter != steps().end(); ++iter) {
-        const boost::shared_ptr<const StepInfo>& stepInfo = iter->second;
+        const std::shared_ptr<const StepInfo>& stepInfo = iter->second;
         SingleStepMatch currentMatch = stepInfo->matches(stepDescription);
         if (currentMatch) {
             matchResult.addMatch(currentMatch);

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -1,9 +1,8 @@
 #include <cucumber-cpp/internal/hook/Tag.hpp>
+#include <memory>
 
 namespace cucumber {
 namespace internal {
-
-using boost::shared_ptr;
 
 Regex & AndTagExpression::csvTagNotationRegex() {
     static Regex r("\\s*\"([^\"]+)\"\\s*(?:,|$)");
@@ -13,7 +12,7 @@ Regex & AndTagExpression::csvTagNotationRegex() {
 AndTagExpression::AndTagExpression() {}
 
 AndTagExpression::AndTagExpression(const std::string &csvTagNotation) {
-    const shared_ptr<RegexMatch> match(csvTagNotationRegex().findAll(csvTagNotation));
+    const std::shared_ptr<RegexMatch> match(csvTagNotationRegex().findAll(csvTagNotation));
     const RegexMatch::submatches_type submatches = match->getSubmatches();
     orExpressions.reserve(submatches.size());
     for (RegexMatch::submatches_type::const_iterator i = submatches.begin(); i != submatches.end(); ++i) {
@@ -37,7 +36,7 @@ Regex & OrTagExpression::csvTagNotationRegex() {
 }
 
 OrTagExpression::OrTagExpression(const std::string &csvTagNotation) {
-    const shared_ptr<RegexMatch> match(csvTagNotationRegex().findAll(csvTagNotation));
+    const std::shared_ptr<RegexMatch> match(csvTagNotationRegex().findAll(csvTagNotation));
     const RegexMatch::submatches_type submatches = match->getSubmatches();
     orTags.reserve(submatches.size());
     for (RegexMatch::submatches_type::const_iterator i = submatches.begin(); i != submatches.end(); ++i) {

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -5,8 +5,6 @@
 #include <json_spirit/json_spirit_writer_template.h>
 #include <json_spirit/json_spirit_writer_options.h>
 
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/foreach.hpp>
 
@@ -89,7 +87,7 @@ void SnippetTextResponse::accept(WireResponseVisitor& visitor) const {
 
 
 namespace {
-    typedef boost::shared_ptr<WireCommand> (*CommandDecoder)(const mValue& jsonArgs);
+    typedef std::shared_ptr<WireCommand> (*CommandDecoder)(const mValue& jsonArgs);
 
     CukeEngine::tags_type getScenarioTags(const mValue& jsonArgs) {
         CukeEngine::tags_type tags;
@@ -102,18 +100,18 @@ namespace {
         return tags;
     }
 
-    boost::shared_ptr<WireCommand> BeginScenarioDecoder(const mValue& jsonArgs) {
-        return boost::make_shared<BeginScenarioCommand>(getScenarioTags(jsonArgs));
+    std::shared_ptr<WireCommand> BeginScenarioDecoder(const mValue& jsonArgs) {
+        return std::make_shared<BeginScenarioCommand>(getScenarioTags(jsonArgs));
     }
 
-    boost::shared_ptr<WireCommand> EndScenarioDecoder(const mValue& jsonArgs) {
-        return boost::make_shared<EndScenarioCommand>(getScenarioTags(jsonArgs));
+    std::shared_ptr<WireCommand> EndScenarioDecoder(const mValue& jsonArgs) {
+        return std::make_shared<EndScenarioCommand>(getScenarioTags(jsonArgs));
     }
 
-    boost::shared_ptr<WireCommand> StepMatchesDecoder(const mValue& jsonArgs) {
+    std::shared_ptr<WireCommand> StepMatchesDecoder(const mValue& jsonArgs) {
         mObject stepMatchesArgs(jsonArgs.get_obj());
         const std::string& nameToMatch(stepMatchesArgs["name_to_match"].get_str());
-        return boost::make_shared<StepMatchesCommand>(nameToMatch);
+        return std::make_shared<StepMatchesCommand>(nameToMatch);
     }
 
     void fillTableArg(const mArray& jsonTableArg, CukeEngine::invoke_table_type& tableArg) {
@@ -151,22 +149,22 @@ namespace {
         }
     }
 
-    boost::shared_ptr<WireCommand> InvokeDecoder(const mValue& jsonArgs) {
+    std::shared_ptr<WireCommand> InvokeDecoder(const mValue& jsonArgs) {
         mObject invokeParams(jsonArgs.get_obj());
 
         CukeEngine::invoke_args_type args;
         CukeEngine::invoke_table_type tableArg;
         const std::string & id(invokeParams["id"].get_str());
         fillInvokeArgs(invokeParams, args, tableArg);
-        return boost::make_shared<InvokeCommand>(id, args, tableArg);
+        return std::make_shared<InvokeCommand>(id, args, tableArg);
     }
 
-    boost::shared_ptr<WireCommand> SnippetTextDecoder(const mValue& jsonArgs) {
+    std::shared_ptr<WireCommand> SnippetTextDecoder(const mValue& jsonArgs) {
         mObject snippetTextArgs(jsonArgs.get_obj());
         const std::string & stepKeyword(snippetTextArgs["step_keyword"].get_str());
         const std::string & stepName(snippetTextArgs["step_name"].get_str());
         const std::string & multilineArgClass(snippetTextArgs["multiline_arg_class"].get_str());
-        return boost::make_shared<SnippetTextCommand>(stepKeyword, stepName, multilineArgClass);
+        return std::make_shared<SnippetTextCommand>(stepKeyword, stepName, multilineArgClass);
     }
 }
 
@@ -181,7 +179,7 @@ static const std::map<std::string, CommandDecoder> commandDecodersMap =
 
 JsonSpiritWireMessageCodec::JsonSpiritWireMessageCodec() {}
 
-boost::shared_ptr<WireCommand> JsonSpiritWireMessageCodec::decode(const std::string &request) const {
+std::shared_ptr<WireCommand> JsonSpiritWireMessageCodec::decode(const std::string &request) const {
     std::istringstream is(request);
     mValue json;
     try {
@@ -202,7 +200,7 @@ boost::shared_ptr<WireCommand> JsonSpiritWireMessageCodec::decode(const std::str
     } catch (...) {
         // LOG Error decoding wire protocol command
     }
-    return boost::make_shared<FailingCommand>();
+    return std::make_shared<FailingCommand>();
 }
 
 namespace {
@@ -311,8 +309,8 @@ std::string WireProtocolHandler::handle(const std::string &request) const {
     std::string response;
     // LOG request
     try {
-        boost::shared_ptr<const WireCommand> command = codec.decode(request);
-        boost::shared_ptr<const WireResponse> wireResponse = command->run(engine);
+        std::shared_ptr<const WireCommand> command = codec.decode(request);
+        std::shared_ptr<const WireResponse> wireResponse = command->run(engine);
         response = codec.encode(*wireResponse);
     } catch (...) {
         response = "[\"fail\"]";

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -6,7 +6,6 @@
 #include <json_spirit/json_spirit_writer_options.h>
 
 #include <boost/assign/list_of.hpp>
-#include <boost/foreach.hpp>
 
 #include <iostream>
 #include <string>
@@ -260,11 +259,11 @@ namespace {
 
         void visit(const StepMatchesResponse& response) {
             mArray jsonMatches;
-            BOOST_FOREACH(StepMatch m, response.getMatchingSteps()) {
+            for(const StepMatch & m : response.getMatchingSteps()) {
                 mObject jsonM;
                 jsonM["id"] = m.id;
                 mArray jsonArgs;
-                BOOST_FOREACH(StepMatchArg ma, m.args) {
+                for(const StepMatchArg & ma : m.args) {
                     mObject jsonMa;
                     jsonMa["val"] = ma.value;
                     jsonMa["pos"] = static_cast<boost::int64_t>(ma.position);

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -5,8 +5,6 @@
 #include <json_spirit/json_spirit_writer_template.h>
 #include <json_spirit/json_spirit_writer_options.h>
 
-#include <boost/assign/list_of.hpp>
-
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -167,14 +165,13 @@ namespace {
     }
 }
 
-static const std::map<std::string, CommandDecoder> commandDecodersMap =
-  boost::assign::map_list_of<std::string, CommandDecoder>
-    ("begin_scenario", BeginScenarioDecoder)
-    ("end_scenario"  , EndScenarioDecoder  )
-    ("step_matches"  , StepMatchesDecoder  )
-    ("invoke"        , InvokeDecoder       )
-    ("snippet_text"  , SnippetTextDecoder  )
-  ;
+static const std::map<std::string, CommandDecoder> commandDecodersMap = {
+    {"begin_scenario", BeginScenarioDecoder},
+    {"end_scenario"  , EndScenarioDecoder  },
+    {"step_matches"  , StepMatchesDecoder  },
+    {"invoke"        , InvokeDecoder       },
+    {"snippet_text"  , SnippetTextDecoder  },
+};
 
 JsonSpiritWireMessageCodec::JsonSpiritWireMessageCodec() {}
 

--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -1,5 +1,4 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp>
-#include <boost/make_shared.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -13,9 +12,9 @@ BeginScenarioCommand::BeginScenarioCommand(const CukeEngine::tags_type& tags) :
     ScenarioCommand(tags) {
 }
 
-boost::shared_ptr<WireResponse> BeginScenarioCommand::run(CukeEngine& engine) const {
+std::shared_ptr<WireResponse> BeginScenarioCommand::run(CukeEngine& engine) const {
     engine.beginScenario(tags);
-    return boost::make_shared<SuccessResponse>();
+    return std::make_shared<SuccessResponse>();
 }
 
 
@@ -23,9 +22,9 @@ EndScenarioCommand::EndScenarioCommand(const CukeEngine::tags_type& tags) :
     ScenarioCommand(tags) {
 }
 
-boost::shared_ptr<WireResponse> EndScenarioCommand::run(CukeEngine& engine) const {
+std::shared_ptr<WireResponse> EndScenarioCommand::run(CukeEngine& engine) const {
     engine.endScenario(tags);
-    return boost::make_shared<SuccessResponse>();
+    return std::make_shared<SuccessResponse>();
 }
 
 
@@ -33,9 +32,9 @@ StepMatchesCommand::StepMatchesCommand(const std::string & stepName) :
     stepName(stepName) {
 }
 
-boost::shared_ptr<WireResponse> StepMatchesCommand::run(CukeEngine& engine) const {
+std::shared_ptr<WireResponse> StepMatchesCommand::run(CukeEngine& engine) const {
     std::vector<StepMatch> matchingSteps = engine.stepMatches(stepName);
-    return boost::make_shared<StepMatchesResponse>(matchingSteps);
+    return std::make_shared<StepMatchesResponse>(matchingSteps);
 }
 
 
@@ -47,16 +46,16 @@ InvokeCommand::InvokeCommand(const std::string & stepId,
     tableArg(tableArg) {
 }
 
-boost::shared_ptr<WireResponse> InvokeCommand::run(CukeEngine& engine) const {
+std::shared_ptr<WireResponse> InvokeCommand::run(CukeEngine& engine) const {
     try {
         engine.invokeStep(stepId, args, tableArg);
-        return boost::make_shared<SuccessResponse>();
+        return std::make_shared<SuccessResponse>();
     } catch (const InvokeFailureException& e) {
-        return boost::make_shared<FailureResponse>(e.getMessage(), e.getExceptionType());
+        return std::make_shared<FailureResponse>(e.getMessage(), e.getExceptionType());
     } catch (const PendingStepException& e) {
-        return boost::make_shared<PendingResponse>(e.getMessage());
+        return std::make_shared<PendingResponse>(e.getMessage());
     } catch (...) {
-        return boost::make_shared<FailureResponse>();
+        return std::make_shared<FailureResponse>();
     }
 }
 
@@ -67,13 +66,13 @@ SnippetTextCommand::SnippetTextCommand(const std::string & keyword, const std::s
     multilineArgClass(multilineArgClass) {
 }
 
-boost::shared_ptr<WireResponse> SnippetTextCommand::run(CukeEngine& engine) const {
-    return boost::make_shared<SnippetTextResponse>(engine.snippetText(keyword, name, multilineArgClass));
+std::shared_ptr<WireResponse> SnippetTextCommand::run(CukeEngine& engine) const {
+    return std::make_shared<SnippetTextResponse>(engine.snippetText(keyword, name, multilineArgClass));
 }
 
 
-boost::shared_ptr<WireResponse> FailingCommand::run(CukeEngine& /*engine*/) const {
-    return boost::make_shared<FailureResponse>();
+std::shared_ptr<WireResponse> FailingCommand::run(CukeEngine& /*engine*/) const {
+    return std::make_shared<FailureResponse>();
 }
 
 }

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -1,5 +1,5 @@
 #include <cucumber-cpp/internal/connectors/wire/WireServer.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 
 namespace cucumber {
 namespace internal {
@@ -80,8 +80,8 @@ UnixSocketServer::UnixSocketServer(const ProtocolHandler *protocolHandler) :
 }
 
 void UnixSocketServer::listen(const std::string& unixPath) {
-    if (boost::filesystem::status(unixPath).type() == boost::filesystem::socket_file)
-        boost::filesystem::remove(unixPath);
+    if (std::filesystem::status(unixPath).type() == std::filesystem::file_type::socket)
+        std::filesystem::remove(unixPath);
 
     doListen(acceptor, stream_protocol::endpoint(unixPath));
 }
@@ -99,7 +99,7 @@ UnixSocketServer::~UnixSocketServer() {
         return;
     std::string path = acceptor.local_endpoint().path();
     // NOTE: this will fail if this path got deleted manually or represents an abstract-namespace socket
-    boost::filesystem::remove(path);
+    std::filesystem::remove(path);
 }
 #endif
 

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -5,7 +5,7 @@
 #include <boost/function.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_log_formatter.hpp>
-#include <boost/thread/once.hpp>
+#include <mutex>
 #include <boost/version.hpp>
 
 using namespace ::boost::unit_test;
@@ -104,8 +104,8 @@ const InvokeResult CukeBoostLogInterceptor::getResult() const {
 }
 
 const InvokeResult BoostStep::invokeStepBody() {
-    static boost::once_flag initialized;
-    boost::call_once(initialized, BoostStep::initBoostTest);
+    static std::once_flag initialized;
+    std::call_once(initialized, BoostStep::initBoostTest);
 
     logInterceptor->reset();
     runWithMasterSuite();

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 
 #include <boost/function.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_log_formatter.hpp>
 #include <boost/thread/once.hpp>

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -2,7 +2,6 @@
 
 #include <sstream>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/test/unit_test.hpp>
@@ -129,7 +128,7 @@ void BoostStep::initBoostTest() {
 }
 
 void BoostStep::runWithMasterSuite() {
-    currentTestBody = boost::bind(&BoostStep::body, this);
+    currentTestBody = std::bind(&BoostStep::body, this);
     
     ::boost::unit_test::framework::run(testCase, false);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocol.hpp>
 #include <iostream>
 #include <boost/program_options.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace {
 
@@ -13,7 +13,7 @@ void acceptWireProtocol(const std::string& host, int port, const std::string& un
     CukeEngineImpl cukeEngine;
     JsonSpiritWireMessageCodec wireCodec;
     WireProtocolHandler protocolHandler(wireCodec, cukeEngine);
-    boost::scoped_ptr<SocketServer> server;
+    std::unique_ptr<SocketServer> server;
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
     if (!unixPath.empty())
     {

--- a/tests/integration/TaggedHookRegistrationTest.cpp
+++ b/tests/integration/TaggedHookRegistrationTest.cpp
@@ -3,9 +3,6 @@
 #include "../utils/HookRegistrationFixture.hpp"
 #include <cucumber-cpp/internal/hook/HookMacros.hpp>
 
-#include <boost/assign.hpp>
-using boost::assign::list_of;
-
 BEFORE("@a") { beforeHookCallMarker << "A"; }
 BEFORE("@a","@b") { beforeHookCallMarker << "B"; }
 BEFORE("@a,@b") { beforeHookCallMarker << "C"; }
@@ -34,7 +31,7 @@ TEST_F(HookRegistrationTest, noTaggedHooksAreInvokedIfNoScenarioTag) {
 }
 
 TEST_F(HookRegistrationTest, orTagsAreEnforced) {
-    const TagExpression::tag_list tags = list_of("b");
+    const TagExpression::tag_list tags = {"b"};
     beginScenario(tags);
     invokeStep();
     endScenario();
@@ -45,7 +42,7 @@ TEST_F(HookRegistrationTest, orTagsAreEnforced) {
 }
 
 TEST_F(HookRegistrationTest, andTagsAreEnforced) {
-    const TagExpression::tag_list tags = list_of("a")("b");
+    const TagExpression::tag_list tags = {"a", "b"};
     beginScenario(tags);
     invokeStep();
     endScenario();

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -2,16 +2,12 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp>
 
 #include <gmock/gmock.h>
-#include <boost/assign/list_of.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <typeinfo>
 
 using namespace cucumber::internal;
 using namespace std;
 using namespace testing;
-
-using boost::assign::list_of;
 
 class MockCukeEngine : public CukeEngine {
 public:

--- a/tests/integration/WireProtocolTest.cpp
+++ b/tests/integration/WireProtocolTest.cpp
@@ -30,7 +30,7 @@ public:
     WireMessageCodecTest() {};
 
 protected:
-    boost::shared_ptr<WireCommand> commandAutoPtr;
+    std::shared_ptr<WireCommand> commandAutoPtr;
 
     WireCommand& decode(const char *jsonStr) {
         commandAutoPtr = codec.decode(jsonStr);
@@ -298,7 +298,7 @@ TEST(WireCommandsTest, succesfulInvokeReturnsSuccess) {
     EXPECT_CALL(engine, invokeStep(_, _, _))
             .Times(1);
 
-    boost::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
+    std::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
     EXPECT_PTRTYPE(SuccessResponse, response.get());
 }
 
@@ -309,7 +309,7 @@ TEST(WireCommandsTest, throwingFailureInvokeReturnsFailure) {
             .Times(1)
             .WillOnce(Throw(InvokeFailureException("A", "B")));
 
-    boost::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
+    std::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
     EXPECT_PTRTYPE(FailureResponse, response.get());
     // TODO Test A and B
 }
@@ -321,7 +321,7 @@ TEST(WireCommandsTest, throwingPendingStepReturnsPending) {
             .Times(1)
             .WillOnce(Throw(PendingStepException("S")));
 
-    boost::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
+    std::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
     EXPECT_PTRTYPE(PendingResponse, response.get());
     // TODO Test S
 }
@@ -333,7 +333,7 @@ TEST(WireCommandsTest, throwingAnythingInvokeReturnsFailure) {
             .Times(1)
             .WillOnce(Throw(string("something")));
 
-    boost::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
+    std::shared_ptr<const WireResponse> response(invokeCommand.run(engine));
     EXPECT_PTRTYPE(FailureResponse, response.get());
     // TODO Test empty
 }

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -3,7 +3,7 @@
 #include <gmock/gmock.h>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <boost/thread.hpp>
 #include <boost/timer.hpp>
 
@@ -61,7 +61,7 @@ class SocketServerTest : public Test {
 
 protected:
     StrictMock<MockProtocolHandler> protocolHandler;
-    boost::scoped_ptr<thread> serverThread;
+    std::unique_ptr<thread> serverThread;
 
     virtual void SetUp() {
         SocketServer* server = createListeningServer();
@@ -82,7 +82,7 @@ protected:
 
 class TCPSocketServerTest : public SocketServerTest {
 protected:
-    boost::scoped_ptr<TCPSocketServer> server;
+    std::unique_ptr<TCPSocketServer> server;
 
     virtual SocketServer* createListeningServer() {
         server.reset(new TCPSocketServer(&protocolHandler));
@@ -144,7 +144,7 @@ TEST_F(TCPSocketServerTest, receiveAndSendsSingleLineMassages) {
 
 class TCPSocketServerLocalhostTest : public SocketServerTest {
 protected:
-  boost::scoped_ptr<TCPSocketServer> server;
+  std::unique_ptr<TCPSocketServer> server;
 
   virtual SocketServer* createListeningServer() {
       server.reset(new TCPSocketServer(&protocolHandler));
@@ -173,7 +173,7 @@ TEST_F(TCPSocketServerLocalhostTest, listensOnLocalhost) {
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 class UnixSocketServerTest : public SocketServerTest {
 protected:
-    boost::scoped_ptr<UnixSocketServer> server;
+    std::unique_ptr<UnixSocketServer> server;
 
     virtual SocketServer* createListeningServer() {
         fs::path socket = fs::temp_directory_path() / fs::unique_path();

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -17,7 +17,6 @@ using namespace boost::asio::ip;
 using namespace boost::asio::local;
 #endif
 using namespace testing;
-using boost::bind;
 using boost::thread;
 namespace fs = boost::filesystem;
 

--- a/tests/unit/ContextManagerTest.cpp
+++ b/tests/unit/ContextManagerTest.cpp
@@ -2,10 +2,9 @@
 
 #include "../utils/ContextManagerTestDouble.hpp"
 
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 using namespace cucumber::internal;
-using boost::weak_ptr;
 
 class ContextManagerTest : public ::testing::Test {
 public:
@@ -25,26 +24,26 @@ class Context1 {};
 class Context2 {};
 
 TEST_F(ContextManagerTest, createsValidContextPointers) {
-    weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
+    std::weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
     ASSERT_EQ(1, contextManager.countContexts());
     ASSERT_FALSE(ctx1.expired());
-    weak_ptr<Context2> ctx2 = contextManager.addContext<Context2>();
+    std::weak_ptr<Context2> ctx2 = contextManager.addContext<Context2>();
     ASSERT_EQ(2, contextManager.countContexts());
     ASSERT_FALSE(ctx2.expired());
 }
 
 TEST_F(ContextManagerTest, allowsCreatingTheSameContextTypeTwice) {
-    weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
+    std::weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
     ASSERT_EQ(1, contextManager.countContexts());
     ASSERT_FALSE(ctx1.expired());
-    weak_ptr<Context1> ctx2 = contextManager.addContext<Context1>();
+    std::weak_ptr<Context1> ctx2 = contextManager.addContext<Context1>();
     ASSERT_EQ(2, contextManager.countContexts());
     ASSERT_FALSE(ctx2.expired());
     ASSERT_NE(ctx1.lock(), ctx2.lock());
 }
 
 TEST_F(ContextManagerTest, purgesContexts) {
-    weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
+    std::weak_ptr<Context1> ctx1 = contextManager.addContext<Context1> ();
     ASSERT_EQ(1, contextManager.countContexts());
     ASSERT_FALSE(ctx1.expired());
     contextManager.purgeContexts();

--- a/tests/unit/RegexTest.cpp
+++ b/tests/unit/RegexTest.cpp
@@ -6,18 +6,17 @@ using namespace boost::assign;
 #include <cucumber-cpp/internal/utils/Regex.hpp>
 using namespace cucumber::internal;
 
-#include <boost/shared_ptr.hpp>
-using boost::shared_ptr;
+#include <memory>
 
 
 TEST(RegexTest, matchesSimpleRegex) {
     Regex exact("^cde$");
 
-    shared_ptr<RegexMatch> match(exact.find("cde"));
+    std::shared_ptr<RegexMatch> match(exact.find("cde"));
     EXPECT_TRUE(match->matches());
     EXPECT_TRUE(match->getSubmatches().empty());
 
-    match = shared_ptr<RegexMatch>(exact.find("abcdefg"));
+    match = std::shared_ptr<RegexMatch>(exact.find("abcdefg"));
     EXPECT_FALSE(match->matches());
     EXPECT_TRUE(match->getSubmatches().empty());
 }
@@ -25,21 +24,21 @@ TEST(RegexTest, matchesSimpleRegex) {
 TEST(RegexTest, matchesRegexWithoutSubmatches) {
     Regex variable("x\\d+x");
 
-    shared_ptr<RegexMatch> match(variable.find("xxxx123xxx"));
+    std::shared_ptr<RegexMatch> match(variable.find("xxxx123xxx"));
     EXPECT_TRUE(match->matches());
 
-    match = shared_ptr<RegexMatch>(variable.find("xxx"));
+    match = std::shared_ptr<RegexMatch>(variable.find("xxx"));
     EXPECT_FALSE(match->matches());
 }
 
 TEST(RegexTest, matchesRegexWithSubmatches) {
     Regex sum("^(\\d+)\\+\\d+=(\\d+)$");
 
-    shared_ptr<RegexMatch> match(sum.find("1+2=3 "));
+    std::shared_ptr<RegexMatch> match(sum.find("1+2=3 "));
     EXPECT_FALSE(match->matches());
     EXPECT_TRUE(match->getSubmatches().empty());
 
-    match = shared_ptr<RegexMatch>(sum.find("42+27=69"));
+    match = std::shared_ptr<RegexMatch>(sum.find("42+27=69"));
     EXPECT_TRUE(match->matches());
     ASSERT_EQ(2, match->getSubmatches().size());
     EXPECT_EQ("42", match->getSubmatches()[0].value);
@@ -49,11 +48,11 @@ TEST(RegexTest, matchesRegexWithSubmatches) {
 TEST(RegexTest, matchesRegexWithOptionalSubmatches) {
     Regex sum("^(\\d+)\\+(\\d+)(?:\\+(\\d+))?=(\\d+)$");
 
-    shared_ptr<RegexMatch> match(sum.find("1+2+3=6"));
+    std::shared_ptr<RegexMatch> match(sum.find("1+2+3=6"));
     EXPECT_TRUE(match->matches());
     ASSERT_EQ(4, match->getSubmatches().size());
 
-    match = shared_ptr<RegexMatch>(sum.find("42+27=69"));
+    match = std::shared_ptr<RegexMatch>(sum.find("42+27=69"));
     EXPECT_TRUE(match->matches());
     ASSERT_EQ(4, match->getSubmatches().size());
     EXPECT_EQ("42", match->getSubmatches()[0].value);
@@ -64,7 +63,7 @@ TEST(RegexTest, matchesRegexWithOptionalSubmatches) {
 
 TEST(RegexTest, findAllDoesNotMatchIfNoTokens) {
     Regex sum("([^,]+)(?:,|$)");
-    shared_ptr<RegexMatch> match(sum.findAll(""));
+    std::shared_ptr<RegexMatch> match(sum.findAll(""));
 
     EXPECT_FALSE(match->matches());
     EXPECT_EQ(0, match->getSubmatches().size());
@@ -72,7 +71,7 @@ TEST(RegexTest, findAllDoesNotMatchIfNoTokens) {
 
 TEST(RegexTest, findReportsCodepointPositions) {
     Regex twoArgs("Some (.+) regexp (.+)");
-    shared_ptr<RegexMatch> match(twoArgs.find("Some カラオケ機 regexp ASCII"));
+    std::shared_ptr<RegexMatch> match(twoArgs.find("Some カラオケ機 regexp ASCII"));
 
     EXPECT_TRUE(match->matches());
     ASSERT_EQ(2, match->getSubmatches().size());
@@ -82,7 +81,7 @@ TEST(RegexTest, findReportsCodepointPositions) {
 
 TEST(RegexTest, findAllExtractsTheFirstGroupOfEveryToken) {
     Regex sum("([^,]+)(?:,|$)");
-    shared_ptr<RegexMatch> match(sum.findAll("a,b,cc"));
+    std::shared_ptr<RegexMatch> match(sum.findAll("a,b,cc"));
 
     EXPECT_TRUE(match->matches());
     EXPECT_EQ(3, match->getSubmatches().size());
@@ -92,7 +91,7 @@ TEST(RegexTest, findAllExtractsTheFirstGroupOfEveryToken) {
 /*
 TEST(RegexTest, findAllHasToMatchTheEntireInput) {
     Regex sum("([^,]+)(?:,|$)");
-    shared_ptr<RegexMatch> match(sum.findAll("1 a,b,cc"));
+    std::shared_ptr<RegexMatch> match(sum.findAll("1 a,b,cc"));
 
     EXPECT_FALSE(match->matches());
     EXPECT_EQ(0, match->getSubmatches().size());

--- a/tests/unit/RegexTest.cpp
+++ b/tests/unit/RegexTest.cpp
@@ -1,8 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <boost/assign/list_of.hpp>
-using namespace boost::assign;
-
 #include <cucumber-cpp/internal/utils/Regex.hpp>
 using namespace cucumber::internal;
 

--- a/tests/unit/StepCallChainTest.cpp
+++ b/tests/unit/StepCallChainTest.cpp
@@ -94,7 +94,7 @@ TEST_F(StepCallChainTest, failsIfNoStep) {
 }
 
 TEST_F(StepCallChainTest, stepExecutionReturnsTheExpectedResult) {
-    boost::shared_ptr<MarkingAroundStepHook> hook(boost::make_shared<MarkingAroundStepHook>());
+    std::shared_ptr<MarkingAroundStepHook> hook(std::make_shared<MarkingAroundStepHook>());
 
     execStepAndCheckSuccess();
 
@@ -109,10 +109,10 @@ TEST_F(StepCallChainTest, stepExecutionReturnsTheExpectedResult) {
 }
 
 TEST_F(StepCallChainTest, aroundHooksAreInvokedInTheCorrectOrder) {
-    boost::shared_ptr<MarkingAroundStepHook>
-        hook1(boost::make_shared<MarkingAroundStepHook>("1", &markers))
-      , hook2(boost::make_shared<MarkingAroundStepHook>("2", &markers))
-      , hook3(boost::make_shared<MarkingAroundStepHook>("3", &markers))
+    std::shared_ptr<MarkingAroundStepHook>
+        hook1(std::make_shared<MarkingAroundStepHook>("1", &markers))
+      , hook2(std::make_shared<MarkingAroundStepHook>("2", &markers))
+      , hook3(std::make_shared<MarkingAroundStepHook>("3", &markers))
       ;
 
     aroundHooks.push_back(hook1);
@@ -134,10 +134,10 @@ TEST_F(StepCallChainTest, argsArePassedToTheStep) {
 }
 
 TEST_F(StepCallChainTest, aroundHooksCanStopTheCallChain) {
-    boost::shared_ptr<MarkingAroundStepHook>
-        hook1(boost::make_shared<MarkingAroundStepHook >("1", &markers))
-      , hook2(boost::make_shared<BlockingAroundStepHook>("2", &markers))
-      , hook3(boost::make_shared<MarkingAroundStepHook >("3", &markers))
+    std::shared_ptr<MarkingAroundStepHook>
+        hook1(std::make_shared<MarkingAroundStepHook >("1", &markers))
+      , hook2(std::make_shared<BlockingAroundStepHook>("2", &markers))
+      , hook3(std::make_shared<MarkingAroundStepHook >("3", &markers))
       ;
 
     aroundHooks.push_back(hook1);

--- a/tests/unit/StepManagerTest.cpp
+++ b/tests/unit/StepManagerTest.cpp
@@ -2,11 +2,9 @@
 
 #include "../utils/StepManagerTestDouble.hpp"
 
-#include <boost/assign/list_of.hpp>
 #include <map>
 
 using namespace std;
-using namespace boost::assign;
 using namespace cucumber::internal;
 
 
@@ -113,11 +111,11 @@ TEST_F(StepManagerTest, extractsParamsFromRegExMatchers) {
     StepManager::addStepDefinition("match no params");
     EXPECT_TRUE(extractedParamsAre("match no params", no_params));
     StepManager::addStepDefinition("match the (\\w+) param");
-    EXPECT_TRUE(extractedParamsAre("match the first param", map_list_of(10, "first")));
+    EXPECT_TRUE(extractedParamsAre("match the first param", {{10, "first"}}));
     StepManager::addStepDefinition("match a (.+)$");
-    EXPECT_TRUE(extractedParamsAre("match a  string  with  spaces  ", map_list_of(8, " string  with  spaces  ")));
+    EXPECT_TRUE(extractedParamsAre("match a  string  with  spaces  ", {{8, " string  with  spaces  "}}));
     StepManager::addStepDefinition("match params (\\w+), (\\w+) and (\\w+)");
-    EXPECT_TRUE(extractedParamsAre("match params A, B and C", map_list_of(13, "A")(16, "B")(22, "C")));
+    EXPECT_TRUE(extractedParamsAre("match params A, B and C", {{13, "A"},{16, "B"},{22, "C"}}));
 }
 
 TEST_F(StepManagerTest, handlesMultipleMatches) {

--- a/tests/unit/TableTest.cpp
+++ b/tests/unit/TableTest.cpp
@@ -1,8 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <boost/assign/list_of.hpp>
-using namespace boost::assign;
-
 #include <cucumber-cpp/internal/Table.hpp>
 using namespace cucumber::internal;
 
@@ -16,11 +13,11 @@ TEST(TableTest, forbidsRowsNotMatchingTableColumnsSize) {
     }, std::range_error);
 
     EXPECT_NO_THROW({
-        t.addRow(list_of("R1"));
+        t.addRow({"R1"});
     });
 
     EXPECT_THROW({
-        t.addRow(list_of("R1")("R2"));
+        t.addRow({"R1", "R2"});
     }, std::range_error);
 }
 
@@ -36,7 +33,7 @@ TEST(TableTest, rowsCannotBeAddedBeforeColumnsAreSet) {
 TEST(TableTest, columnsCannotBeChangesAfterRowsAreAdded) {
     Table t;
     t.addColumn("C1");
-    t.addRow(list_of("R1"));
+    t.addRow({"R1"});
 
     EXPECT_THROW({
         t.addColumn("C2");
@@ -51,16 +48,16 @@ TEST(TableTest, addedRowsMatchColumnDefinition) {
 
     ASSERT_EQ(0, t.hashes().size());
 
-    t.addRow(list_of("R11")("R12")("R13"));
+    t.addRow({"R11", "R12", "R13"});
     Table::hashes_type hashes = t.hashes();
     ASSERT_EQ(1, hashes.size());
     EXPECT_EQ("R11", hashes[0]["C1"]);
     EXPECT_EQ("R12", hashes[0]["C2"]);
     EXPECT_EQ("R13", hashes[0]["C3"]);
 
-    t.addRow(list_of("R21")("R22")("R23"));
-    t.addRow(list_of("R31")("R32")("R33"));
-    t.addRow(list_of("R41")("R42")("R43"));
+    t.addRow({"R21", "R22", "R23"});
+    t.addRow({"R31", "R32", "R33"});
+    t.addRow({"R41", "R42", "R43"});
     hashes = t.hashes();
     ASSERT_EQ(4, hashes.size());
     EXPECT_EQ("R21", hashes[1]["C1"]);

--- a/tests/unit/TagTest.cpp
+++ b/tests/unit/TagTest.cpp
@@ -4,71 +4,68 @@
 
 using namespace cucumber::internal;
 
-#include <boost/assign/list_of.hpp>
-using namespace boost::assign;
-
 TEST(TagTest, emptyOrExpressionMatchesNoTag) {
     OrTagExpression tagExpr("");
-    EXPECT_FALSE(tagExpr.matches(list_of("x")));
-    EXPECT_FALSE(tagExpr.matches(list_of("a")("b")));
+    EXPECT_FALSE(tagExpr.matches({"x"}));
+    EXPECT_FALSE(tagExpr.matches({"a", "b"}));
 }
 
 TEST(TagTest, orExpressionsMatchTheTagSpecified) {
     OrTagExpression tagExpr("@a");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")));
+    EXPECT_TRUE(tagExpr.matches({"a"}));
+    EXPECT_FALSE(tagExpr.matches({"x"}));
 }
 
 TEST(TagTest, orExpressionsMatchAnyTagSpecified) {
     OrTagExpression tagExpr("@a,@b,@c");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")));
-    EXPECT_TRUE(tagExpr.matches(list_of("b")));
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("b")));
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("b")("c")));
-    EXPECT_TRUE(tagExpr.matches(list_of("x")("a")("b")));
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("y")));
-    EXPECT_TRUE(tagExpr.matches(list_of("x")("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")("y")("z")));
+    EXPECT_TRUE(tagExpr.matches({"a"}));
+    EXPECT_TRUE(tagExpr.matches({"b"}));
+    EXPECT_TRUE(tagExpr.matches({"a", "b"}));
+    EXPECT_TRUE(tagExpr.matches({"a", "b", "c"}));
+    EXPECT_TRUE(tagExpr.matches({"x", "a", "b"}));
+    EXPECT_TRUE(tagExpr.matches({"a", "y"}));
+    EXPECT_TRUE(tagExpr.matches({"x", "b"}));
+    EXPECT_FALSE(tagExpr.matches({"x", "y", "z"}));
 }
 
 TEST(TagTest, orExpressionsAllowSpaces) {
     OrTagExpression tagExpr("@a, @b,@c");
-    EXPECT_TRUE(tagExpr.matches(list_of("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")));
+    EXPECT_TRUE(tagExpr.matches({"b"}));
+    EXPECT_FALSE(tagExpr.matches({"x"}));
 }
 
 
 TEST(TagTest, emptyAndExpressionMatchesAnyTag) {
     AndTagExpression tagExpr("");
-    EXPECT_TRUE(tagExpr.matches(list_of("x")));
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("b")));
+    EXPECT_TRUE(tagExpr.matches({"x"}));
+    EXPECT_TRUE(tagExpr.matches({"a", "b"}));
 }
 
 TEST(TagTest, singleAndExpressionMatchesTheTagSpecified) {
     AndTagExpression tagExpr("\"@a\"");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")));
+    EXPECT_TRUE(tagExpr.matches({"a"}));
+    EXPECT_FALSE(tagExpr.matches({"x"}));
 }
 
 TEST(TagTest, andExpressionsMatchEveryTagSpecified) {
     AndTagExpression tagExpr("\"@a\",\"@b\"");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("b")));
-    EXPECT_TRUE(tagExpr.matches(list_of("x")("a")("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("a")));
-    EXPECT_FALSE(tagExpr.matches(list_of("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("a")("y")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")("y")));
+    EXPECT_TRUE(tagExpr.matches({"a", "b"}));
+    EXPECT_TRUE(tagExpr.matches({"x", "a", "b"}));
+    EXPECT_FALSE(tagExpr.matches({"a"}));
+    EXPECT_FALSE(tagExpr.matches({"b"}));
+    EXPECT_FALSE(tagExpr.matches({"a", "y"}));
+    EXPECT_FALSE(tagExpr.matches({"x", "b"}));
+    EXPECT_FALSE(tagExpr.matches({"x", "y"}));
 }
 
 TEST(TagTest, andExpressionsAllowSpaces) {
     AndTagExpression tagExpr(" \"@a\" , \"@b\" ");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("b")));
-    EXPECT_FALSE(tagExpr.matches(list_of("a")));
+    EXPECT_TRUE(tagExpr.matches({"a", "b"}));
+    EXPECT_FALSE(tagExpr.matches({"a"}));
 }
 
 TEST(TagTest, compositeTagExpressionsAreHandled) {
     AndTagExpression tagExpr("\"@a,@b\", \"@c\", \"@d,@e,@f\"");
-    EXPECT_TRUE(tagExpr.matches(list_of("a")("c")("d")));
-    EXPECT_FALSE(tagExpr.matches(list_of("x")("c")("f")));
+    EXPECT_TRUE(tagExpr.matches({"a", "c", "d"}));
+    EXPECT_FALSE(tagExpr.matches({"x", "c", "f"}));
 }

--- a/tests/utils/CukeCommandsFixture.hpp
+++ b/tests/utils/CukeCommandsFixture.hpp
@@ -5,10 +5,10 @@
 #include <cucumber-cpp/internal/drivers/GenericDriver.hpp>
 #include "StepManagerTestDouble.hpp"
 
-#include <boost/make_shared.hpp>
+#include <gtest/gtest.h>
+#include <memory>
 
 using namespace cucumber::internal;
-using boost::shared_ptr;
 
 class EmptyStep : public GenericStep {
     void body() {}
@@ -32,7 +32,7 @@ protected:
 
     template<class T>
     void addStepToManager(const std::string &matcher) {
-        stepId = StepManager::addStep(boost::make_shared<StepInvoker<T> >(matcher, ""));
+        stepId = StepManager::addStep(std::make_shared<StepInvoker<T> >(matcher, ""));
     }
 
     virtual void TearDown() {

--- a/tests/utils/HookRegistrationFixture.hpp
+++ b/tests/utils/HookRegistrationFixture.hpp
@@ -5,7 +5,7 @@
 
 #include "CukeCommandsFixture.hpp"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <sstream>
 
 using namespace cucumber::internal;
@@ -64,10 +64,10 @@ static const InvokeArgs NO_INVOKE_ARGS;
 
 class HookRegistrationTest : public CukeCommandsFixture {
 protected:
-    shared_ptr<Scenario> emptyScenario;
+    std::shared_ptr<Scenario> emptyScenario;
 
     HookRegistrationTest() {
-        emptyScenario = boost::make_shared<Scenario>();
+        emptyScenario = std::make_shared<Scenario>();
     }
 
     Scenario *getEmptyScenario() {

--- a/tests/utils/StepManagerTestDouble.hpp
+++ b/tests/utils/StepManagerTestDouble.hpp
@@ -61,7 +61,7 @@ public:
     }
 
     static step_id_type addStepDefinition(const std::string &stepMatcher) {
-        return addStep(boost::make_shared<StepInfoNoOp>(stepMatcher, ""));
+        return addStep(std::make_shared<StepInfoNoOp>(stepMatcher, ""));
     }
 
     static step_id_type addStepDefinitionWithId(step_id_type desiredId, const std::string &stepMatcher) {
@@ -70,7 +70,7 @@ public:
 
     static step_id_type addStepDefinitionWithId(step_id_type desiredId, const std::string &stepMatcher,
             const std::string source) {
-        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoNoOp>(stepMatcher, source));
+        std::shared_ptr<StepInfo> stepInfo(std::make_shared<StepInfoNoOp>(stepMatcher, source));
         stepInfo->id = desiredId;
         return addStep(stepInfo);
     }
@@ -81,13 +81,13 @@ public:
 
     static step_id_type addPendingStepDefinitionWithId(step_id_type desiredId,
             const std::string &stepMatcher, const char *description) {
-        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoPending>(stepMatcher, description));
+        std::shared_ptr<StepInfo> stepInfo(std::make_shared<StepInfoPending>(stepMatcher, description));
         stepInfo->id = desiredId;
         return addStep(stepInfo);
     }
 
     static step_id_type addTableStepDefinitionWithId(step_id_type desiredId, const std::string &stepMatcher, const unsigned short expectedSize) {
-        boost::shared_ptr<StepInfo> stepInfo(boost::make_shared<StepInfoWithTableArg>(stepMatcher, expectedSize));
+        std::shared_ptr<StepInfo> stepInfo(std::make_shared<StepInfoWithTableArg>(stepMatcher, expectedSize));
         stepInfo->id = desiredId;
         return addStep(stepInfo);
     }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Using C++ standard library where possible instead of boost.

## Details

Many boost functionality moved into the C++ standard library over the years. This PR uses the functionality form the standard library instead of boost.

The minimal required C++ standard is C++17.

## Motivation and Context

This is a modernization of the code base.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

No functional changes were made. All tests run in the CI.

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
