### PR TITLE
refactoring: programmatically generate temporary file name in test

### DIFF
--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <random>
 #include <thread>
 #include <chrono>
 
@@ -171,10 +172,7 @@ protected:
     std::unique_ptr<UnixSocketServer> server;
 
     virtual SocketServer* createListeningServer() {
-      char filename[L_tmpnam];
-      if (!std::tmpnam(filename)) {
-          throw std::runtime_error("unable to create name for temporary file");
-      }
+        const std::string filename = std::filesystem::temp_directory_path() / randomString();
         server.reset(new UnixSocketServer(&protocolHandler));
         server->listen(filename);
         return server.get();
@@ -182,6 +180,18 @@ protected:
 
     virtual void destroyListeningServer() {
         server.reset();
+    }
+
+private:
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::uniform_int_distribution<> distrib{0, 15};
+
+    std::string randomString() {
+        std::stringstream out{};
+        for (std::size_t i = 0; i < 16; i++)
+            out << std::hex << distrib(gen);
+        return out.str();
     }
 };
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Latest gcc throws errors when using tmpnam. Generate temporary file name within the test to work around. It has the same shortcomings as using tmpnam, but they are no risk as it is used only in the tests.

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

Test didn't compile anymore on my Linux machine.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It is within a test. The test passes.

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
