### PR TITLE
refactoring: use stl regex instead of boost::regex

### DIFF
--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -23,7 +23,6 @@ jobs:
         gcovr \
         git \
         libboost-program-options-dev \
-        libboost-regex-dev \
         libboost-system-dev \
         libboost-test-dev \
         make \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ else()
 endif()
 
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(CUKE_CORE_BOOST_LIBS system regex program_options)
+set(CUKE_CORE_BOOST_LIBS system program_options)
 if(CUKE_ENABLE_BOOST_TEST)
     # "An external test runner utility is required to link with dynamic library" (Boost User's Guide)
     set(Boost_USE_STATIC_LIBS OFF)
@@ -162,13 +162,6 @@ if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
             "COMPILE_DEFINITIONS" BOOST_ERROR_CODE_HEADER_ONLY=1
         )
     endif()
-endif()
-if(Boost_REGEX_LIBRARY AND NOT TARGET Boost::regex)
-    add_library(Boost::regex ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::regex PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_REGEX_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::boost"
-    )
 endif()
 if(Boost_PROGRAM_OPTIONS_LIBRARY AND NOT TARGET Boost::program_options)
     add_library(Boost::program_options ${LIBRARY_TYPE} IMPORTED)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It relies on a few executables:
 It relies on a few libraries:
 
 * [Boost](http://www.boost.org/) 1.46 or later (1.51+ on Windows).
-  Required libraries: *system*, *regex* and *program_options*.
+  Required libraries: *system* and *program_options*.
   Optional library for Boost Test driver: *test*.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.
   Optional for the GTest driver. By default downloaded and built by CMake.

--- a/include/cucumber-cpp/internal/utils/Regex.hpp
+++ b/include/cucumber-cpp/internal/utils/Regex.hpp
@@ -4,7 +4,7 @@
 #include <cstddef>
 #include <vector>
 
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace cucumber {
 namespace internal {
@@ -31,18 +31,19 @@ protected:
 
 class FindRegexMatch : public RegexMatch {
 public:
-    FindRegexMatch(const boost::regex &regexImpl, const std::string &expression);
+    FindRegexMatch(const std::regex &regexImpl, const std::string &expression);
 };
 
 class FindAllRegexMatch : public RegexMatch {
 public:
-    FindAllRegexMatch(const boost::regex &regexImpl, const std::string &expression);
+    FindAllRegexMatch(const std::regex &regexImpl, const std::string &expression);
 };
 
 
 class Regex {
 private:
-    boost::regex regexImpl;
+    std::regex regexImpl;
+    const std::string regexString;
 
 public:
     Regex(std::string expr);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,7 +83,6 @@ foreach(TARGET
     target_link_libraries(${TARGET}
         PUBLIC
             Boost::boost
-            Boost::regex
         PRIVATE
             ${CUKE_EXTRA_PRIVATE_LIBRARIES}
     )

--- a/src/CukeCommands.cpp
+++ b/src/CukeCommands.cpp
@@ -47,11 +47,11 @@ const std::string CukeCommands::snippetText(const std::string stepKeyword, const
 }
 
 const std::string CukeCommands::escapeRegex(const std::string reg) const {
-    return regex_replace(reg, boost::regex("[\\|\\(\\)\\[\\]\\{\\}\\^\\$\\*\\+\\?\\.\\\\]"), "\\\\&", boost::match_default | boost::format_sed);
+    return regex_replace(reg, std::regex("[\\|\\(\\)\\[\\]\\{\\}\\^\\$\\*\\+\\?\\.\\\\]"), "\\\\&", std::regex_constants::match_default | std::regex_constants::format_sed);
 }
 
 const std::string CukeCommands::escapeCString(const std::string str) const {
-    return regex_replace(str, boost::regex("[\"\\\\]"), "\\\\&", boost::match_default | boost::format_sed);
+    return regex_replace(str, std::regex("[\"\\\\]"), "\\\\&", std::regex_constants::match_default | std::regex_constants::format_sed);
 }
 
 MatchResult CukeCommands::stepMatches(const std::string description) const {

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -6,7 +6,8 @@ namespace cucumber {
 namespace internal {
 
 Regex::Regex(std::string regularExpression) :
-    regexImpl(regularExpression.c_str()) {
+    regexImpl(regularExpression),
+    regexString(regularExpression) {
 }
 
 bool RegexMatch::matches() {
@@ -18,7 +19,7 @@ const RegexMatch::submatches_type & RegexMatch::getSubmatches() {
 }
 
 std::string Regex::str() const {
-    return regexImpl.str();
+    return regexString;
 }
 
 std::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
@@ -36,12 +37,11 @@ std::ptrdiff_t utf8CodepointOffset(const std::string& expression,
 }
 } // namespace
 
-FindRegexMatch::FindRegexMatch(const boost::regex& regexImpl, const std::string& expression) {
-    boost::smatch matchResults;
-    regexMatched = boost::regex_search(
-        expression, matchResults, regexImpl, boost::regex_constants::match_extra);
+FindRegexMatch::FindRegexMatch(const std::regex& regexImpl, const std::string& expression) {
+    std::smatch matchResults;
+    regexMatched = std::regex_search(expression, matchResults, regexImpl);
     if (regexMatched) {
-        boost::smatch::const_iterator i = matchResults.begin();
+        std::smatch::const_iterator i = matchResults.begin();
         if (i != matchResults.end())
             // Skip capture group 0 which is the whole match, not a user marked sub-expression
             ++i;
@@ -60,9 +60,9 @@ std::shared_ptr<RegexMatch> Regex::findAll(const std::string &expression) const 
     return std::make_shared<FindAllRegexMatch>(regexImpl, expression);
 }
 
-FindAllRegexMatch::FindAllRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
-    boost::sregex_token_iterator i(expression.begin(), expression.end(), regexImpl, 1, boost::regex_constants::match_continuous);
-    const boost::sregex_token_iterator end;
+FindAllRegexMatch::FindAllRegexMatch(const std::regex &regexImpl, const std::string &expression) {
+    std::sregex_token_iterator i(expression.begin(), expression.end(), regexImpl, 1, std::regex_constants::match_continuous);
+    const std::sregex_token_iterator end;
     for (; i != end; ++i) {
         RegexSubmatch s = {*i, -1};
         submatches.push_back(s);

--- a/tests/utils/DriverTestRunner.hpp
+++ b/tests/utils/DriverTestRunner.hpp
@@ -4,6 +4,7 @@
 #include "StepManagerTestDouble.hpp"
 #include <cucumber-cpp/internal/CukeCommands.hpp>
 
+#include <cstring>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Use standard library regex instead of boost one.

## Details

Refactoring to remove no longer needed dependencies.
This removes the support for repeated captures (i.e. boost::regex_constants::match_extra), which may break some use cases. It is expected that such use cases are rare.

## Motivation and Context

Less dependencies for functionality that is provided by the standard library. 

## How Has This Been Tested?

This is a refactoring, it should not change the behavior (expect for repeated captures). All automated tests still work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [x] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
