### PR TITLE
remove boost::multi_array

### DIFF
--- a/include/cucumber-cpp/internal/CukeEngine.hpp
+++ b/include/cucumber-cpp/internal/CukeEngine.hpp
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/multi_array.hpp>
-
 #include <cucumber-cpp/internal/CukeExport.hpp>
 
 namespace cucumber {
@@ -65,7 +63,7 @@ public:
 class CukeEngine {
 private:
     typedef std::vector<std::string> string_array;
-    typedef boost::multi_array<std::string, 2> string_2d_array;
+    typedef std::vector<std::vector<std::string>> string_2d_array;
 
 public:
     typedef string_array tags_type;

--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -45,24 +45,22 @@ void CukeEngineImpl::beginScenario(const tags_type& tags) {
 void CukeEngineImpl::invokeStep(
     const std::string& id, const invoke_args_type& args, const invoke_table_type& tableArg
 ) {
-    typedef invoke_table_type::index table_index;
-
     InvokeArgs commandArgs;
     try {
         for (const std::string& a : args) {
             commandArgs.addArg(a);
         }
 
-        if (tableArg.shape()[0] > 1 && tableArg.shape()[1] > 0) {
+        if (!tableArg.empty() && !tableArg.front().empty()) {
             Table& commandTableArg = commandArgs.getVariableTableArg();
-            for (table_index j = 0; j < table_index(tableArg.shape()[1]); ++j) {
-                commandTableArg.addColumn(tableArg[0][j]);
+            for (const auto& arg : tableArg[0]) {
+                commandTableArg.addColumn(arg);
             }
 
-            for (table_index i = 1; i < table_index(tableArg.shape()[0]); ++i) {
+            for (std::size_t i = 1; i < tableArg.size(); ++i) {
                 Table::row_type row;
-                for (table_index j = 0; j < table_index(tableArg.shape()[1]); ++j) {
-                    row.push_back(tableArg[i][j]);
+                for (const auto& arg : tableArg[i]) {
+                    row.push_back(arg);
                 }
                 commandTableArg.addRow(row);
             }

--- a/src/connectors/wire/WireProtocol.cpp
+++ b/src/connectors/wire/WireProtocol.cpp
@@ -112,12 +112,12 @@ void fillTableArg(const mArray& jsonTableArg, CukeEngine::invoke_table_type& tab
     size_type rows = jsonTableArg.size();
     if (rows > 0) {
         size_type columns = jsonTableArg[0].get_array().size();
-        tableArg.resize(boost::extents[rows][columns]);
+        tableArg.resize(rows);
         for (size_type i = 0; i < rows; ++i) {
             const mArray& jsonRow(jsonTableArg[i].get_array());
             if (jsonRow.size() == columns) {
                 for (size_type j = 0; j < columns; ++j) {
-                    tableArg[i][j] = jsonRow[j].get_str();
+                    tableArg[i].push_back(jsonRow[j].get_str());
                 }
             } else {
                 // TODO: Invalid row
@@ -257,7 +257,7 @@ public:
             for (const StepMatchArg& ma : m.args) {
                 mObject jsonMa;
                 jsonMa["val"] = ma.value;
-                jsonMa["pos"] = static_cast<boost::int64_t>(ma.position);
+                jsonMa["pos"] = static_cast<int64_t>(ma.position);
                 jsonArgs.push_back(jsonMa);
             }
             jsonM["args"] = jsonArgs;


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Replace boost::multi_array with vector of vector.

## Details

## Motivation and Context

Remove general dependency from boost by using stl instead. Eventually cucumber-cpp can be used without boost, removing a large dependency.

## How Has This Been Tested?

It is a refactoring. All tests pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
