### PR TITLE
cpp 14 usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,15 @@ set(CUKE_ENABLE_SANITIZER       "OFF" CACHE STRING "Sanitizer to use for checkin
 set_property(CACHE CUKE_ENABLE_SANITIZER PROPERTY STRINGS OFF "address" "thread" "undefined")
 option(CUKE_TESTS_VALGRIND      "Enable tests within Valgrind" OFF)
 set(GMOCK_SRC_DIR "" CACHE STRING "Google Mock framework sources path (otherwise downloaded)")
-set(GMOCK_VER "1.11.0" CACHE STRING "Google Mock framework version to be used")
+set(GMOCK_VER "1.14.0" CACHE STRING "Google Mock framework version to be used")
 
-# according to: https://github.com/google/googletest/tree/release-1.10.0#18x-release
-# the 1.8.x is the last release that works with pre-C++11 compilers.
-if(GMOCK_VER VERSION_GREATER_EQUAL "1.9.0")
+# according to: https://github.com/google/googletest/releases/tag/v1.13.0
+# the 1.12.x is the last release that works with pre-C++14 compilers.
+if(GMOCK_VER VERSION_GREATER_EQUAL "1.14.0")
     if(NOT DEFINED CMAKE_CXX_STANDARD)
-        set(CMAKE_CXX_STANDARD 11)
-    elseif(CMAKE_CXX_STANDARD LESS 11)
-        message(FATAL_ERROR "C++11 (above) is required by googletest version: ${GMOCK_VER}")
+        set(CMAKE_CXX_STANDARD 14)
+    elseif(CMAKE_CXX_STANDARD LESS 14)
+        message(FATAL_ERROR "C++14 (above) is required by googletest version: ${GMOCK_VER}")
     endif()
 endif()
 

--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -353,6 +353,11 @@ if(NOT (${GMOCK_LIBRARY_EXISTS} AND ${GTEST_LIBRARY_EXISTS}))
                 set(GMOCK_LIBRARY "${GMOCK_BIN_DIR}/lib/${CMAKE_CFG_INTDIR}/${GTEST_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}")
                 set(GMOCK_MAIN_LIBRARY "${GMOCK_BIN_DIR}/lib/${CMAKE_CFG_INTDIR}/${GTEST_LIBRARY_PREFIX}gmock_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
             endif()
+            if(GMOCK_VER VERSION_GREATER_EQUAL "1.12.1")
+                set(GTEST_TAG_PREFIX "v")
+            else()
+                set(GTEST_TAG_PREFIX "release-")
+            endif()
             mark_as_advanced(GTEST_LIBRARY)
             mark_as_advanced(GTEST_MAIN_LIBRARY)
             mark_as_advanced(GMOCK_LIBRARY)
@@ -361,7 +366,7 @@ if(NOT (${GMOCK_LIBRARY_EXISTS} AND ${GTEST_LIBRARY_EXISTS}))
             externalproject_add(
                 gmock
                 GIT_REPOSITORY "https://github.com/google/googletest.git"
-                GIT_TAG "release-${GMOCK_VER}"
+                GIT_TAG "${GTEST_TAG_PREFIX}${GMOCK_VER}"
                 PREFIX ${GMOCK_ROOT}
                 INSTALL_COMMAND ""
                 LOG_DOWNLOAD ON


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

googletest has changed to cpp standard 14. To use cucumber-cpp with actual version compile for versions that require CPP 14 is enabled now 
 
## Details

<!--- Describe your changes in detail -->

## Motivation and Context

use  current versions of googletest framework

