### PR TITLE
List headers in cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,14 +37,41 @@ if(TARGET Qt5::Test)
     list(APPEND CUKE_EXTRA_PRIVATE_LIBRARIES Qt5::Test)
 endif()
 
-if(CMAKE_EXTRA_GENERATOR OR MSVC_IDE)
-    message(STATUS "Adding header files to project")
-    file(GLOB_RECURSE CUKE_HEADERS "${CUKE_INCLUDE_DIR}/cucumber-cpp/*.hpp")
-    if(MSVC_IDE)
-        source_group("Header Files" FILES ${CUKE_HEADERS})
-    endif()
-    list(APPEND CUKE_SOURCES ${CUKE_HEADERS})
+message(STATUS "Adding header files to project")
+set(CUKE_HEADERS
+    ../include/cucumber-cpp/autodetect.hpp
+    ../include/cucumber-cpp/defs.hpp
+    ../include/cucumber-cpp/generic.hpp
+    ../include/cucumber-cpp/internal/ContextManager.hpp
+    ../include/cucumber-cpp/internal/CukeCommands.hpp
+    ../include/cucumber-cpp/internal/CukeEngine.hpp
+    ../include/cucumber-cpp/internal/CukeEngineImpl.hpp
+    ../include/cucumber-cpp/internal/Macros.hpp
+    ../include/cucumber-cpp/internal/RegistrationMacros.hpp
+    ../include/cucumber-cpp/internal/Scenario.hpp
+    ../include/cucumber-cpp/internal/Table.hpp
+    ../include/cucumber-cpp/internal/connectors/wire/ProtocolHandler.hpp
+    ../include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+    ../include/cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp
+    ../include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+    ../include/cucumber-cpp/internal/defs.hpp
+    ../include/cucumber-cpp/internal/drivers/BoostDriver.hpp
+    ../include/cucumber-cpp/internal/drivers/DriverSelector.hpp
+    ../include/cucumber-cpp/internal/drivers/GTestDriver.hpp
+    ../include/cucumber-cpp/internal/drivers/GenericDriver.hpp
+    ../include/cucumber-cpp/internal/drivers/QtTestDriver.hpp
+    ../include/cucumber-cpp/internal/hook/HookMacros.hpp
+    ../include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+    ../include/cucumber-cpp/internal/hook/Tag.hpp
+    ../include/cucumber-cpp/internal/step/StepMacros.hpp
+    ../include/cucumber-cpp/internal/step/StepManager.hpp
+    ../include/cucumber-cpp/internal/utils/IndexSequence.hpp
+    ../include/cucumber-cpp/internal/utils/Regex.hpp
+)
+if(MSVC_IDE)
+    source_group("Header Files" FILES ${CUKE_HEADERS})
 endif()
+list(APPEND CUKE_SOURCES ${CUKE_HEADERS})
 
 # Library for unit tests relying on internals
 add_library(cucumber-cpp-internal STATIC ${CUKE_SOURCES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,19 @@
+add_library(utils INTERFACE
+    utils/HookRegistrationFixture.hpp
+    utils/ContextManagerTestDouble.hpp
+    utils/DriverTestRunner.hpp
+    utils/CukeCommandsFixture.hpp
+    utils/StepManagerTestDouble.hpp
+)
+target_include_directories(utils INTERFACE
+    .
+)
+
 function(cuke_add_driver_test TEST_FILE)
     get_filename_component(TEST_NAME ${TEST_FILE} NAME)
     message(STATUS "Adding " ${TEST_NAME})
     add_executable(${TEST_NAME} ${TEST_FILE}.cpp)
-    target_link_libraries(${TEST_NAME} PRIVATE cucumber-cpp-internal ${ARGN})
+    target_link_libraries(${TEST_NAME} PRIVATE cucumber-cpp-internal utils ${ARGN})
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endfunction()
 
@@ -11,7 +22,7 @@ if(TARGET GMock::Main)
         get_filename_component(TEST_NAME ${TEST_FILE} NAME)
         message(STATUS "Adding " ${TEST_NAME})
         add_executable(${TEST_NAME} ${TEST_FILE}.cpp)
-        target_link_libraries(${TEST_NAME} PRIVATE cucumber-cpp-internal ${ARGN} GMock::Main)
+        target_link_libraries(${TEST_NAME} PRIVATE cucumber-cpp-internal utils ${ARGN} GMock::Main)
         gtest_add_tests(${TEST_NAME} "" ${TEST_FILE}.cpp)
         # Run all tests in executable at once too. This ensures that the used fixtures get tested
         # properly too. Additionally gather the output in jUnit compatible output for CI.

--- a/tests/integration/ContextHandlingTest.cpp
+++ b/tests/integration/ContextHandlingTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../utils/ContextManagerTestDouble.hpp"
+#include "utils/ContextManagerTestDouble.hpp"
 
 using namespace std;
 using namespace cucumber::internal;

--- a/tests/integration/HookRegistrationTest.cpp
+++ b/tests/integration/HookRegistrationTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../utils/HookRegistrationFixture.hpp"
+#include "utils/HookRegistrationFixture.hpp"
 
 #include <cucumber-cpp/internal/hook/HookMacros.hpp>
 

--- a/tests/integration/TaggedHookRegistrationTest.cpp
+++ b/tests/integration/TaggedHookRegistrationTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../utils/HookRegistrationFixture.hpp"
+#include "utils/HookRegistrationFixture.hpp"
 #include <cucumber-cpp/internal/hook/HookMacros.hpp>
 
 BEFORE("@a") {

--- a/tests/integration/drivers/BoostDriverTest.cpp
+++ b/tests/integration/drivers/BoostDriverTest.cpp
@@ -2,7 +2,7 @@
 #include <boost/test/unit_test.hpp>
 #include <cucumber-cpp/autodetect.hpp>
 
-#include "../../utils/DriverTestRunner.hpp"
+#include "utils/DriverTestRunner.hpp"
 
 using namespace cucumber;
 

--- a/tests/integration/drivers/GTestDriverTest.cpp
+++ b/tests/integration/drivers/GTestDriverTest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <cucumber-cpp/autodetect.hpp>
 
-#include "../../utils/DriverTestRunner.hpp"
+#include "utils/DriverTestRunner.hpp"
 
 using namespace cucumber;
 

--- a/tests/integration/drivers/GenericDriverTest.cpp
+++ b/tests/integration/drivers/GenericDriverTest.cpp
@@ -1,6 +1,6 @@
 #include <cucumber-cpp/generic.hpp>
 
-#include "../../utils/DriverTestRunner.hpp"
+#include "utils/DriverTestRunner.hpp"
 
 using namespace cucumber;
 

--- a/tests/integration/drivers/QtTestDriverTest.cpp
+++ b/tests/integration/drivers/QtTestDriverTest.cpp
@@ -1,7 +1,7 @@
 #include <QtTest>
 #include <cucumber-cpp/autodetect.hpp>
 
-#include "../../utils/DriverTestRunner.hpp"
+#include "utils/DriverTestRunner.hpp"
 
 using namespace cucumber;
 

--- a/tests/unit/ContextManagerTest.cpp
+++ b/tests/unit/ContextManagerTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../utils/ContextManagerTestDouble.hpp"
+#include "utils/ContextManagerTestDouble.hpp"
 
 #include <memory>
 

--- a/tests/unit/CukeCommandsTest.cpp
+++ b/tests/unit/CukeCommandsTest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cucumber-cpp/internal/step/StepMacros.hpp>
-#include "../utils/CukeCommandsFixture.hpp"
+#include "utils/CukeCommandsFixture.hpp"
 
 #include <boost/config.hpp>
 

--- a/tests/unit/StepManagerTest.cpp
+++ b/tests/unit/StepManagerTest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../utils/StepManagerTestDouble.hpp"
+#include "utils/StepManagerTestDouble.hpp"
 
 #include <map>
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

List production code header files in CMakeLists.

## Details

## Motivation and Context

I work with QtCreator. That only shows the files listed in CMakeLists.txt, hence I don't see the header files by default. Also search does only search listed files.

There is already some code to add header files. This change simplifies that code a bit by removing some condition logic.

## How Has This Been Tested?

Should not affect any code. Tested with existing automated tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
