### PR TITLE
Remove dependency to Boost

### DIFF
--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -22,7 +22,7 @@ jobs:
         g++ \
         gcovr \
         git \
-        libboost-system-dev \
+        libasio-dev \
         libboost-test-dev \
         libtclap-dev \
         make \

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -22,9 +22,9 @@ jobs:
         g++ \
         gcovr \
         git \
-        libboost-program-options-dev \
         libboost-system-dev \
         libboost-test-dev \
+        libtclap-dev \
         make \
         ninja-build \
         nlohmann-json3-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 set(BOOST_MIN_VERSION "1.70")
 
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(CUKE_CORE_BOOST_LIBS system program_options)
+set(CUKE_CORE_BOOST_LIBS system)
 if(CUKE_ENABLE_BOOST_TEST)
     # "An external test runner utility is required to link with dynamic library" (Boost User's Guide)
     set(Boost_USE_STATIC_LIBS OFF)
@@ -154,13 +154,6 @@ if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
             "COMPILE_DEFINITIONS" BOOST_ERROR_CODE_HEADER_ONLY=1
         )
     endif()
-endif()
-if(Boost_PROGRAM_OPTIONS_LIBRARY AND NOT TARGET Boost::program_options)
-    add_library(Boost::program_options ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::program_options PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_PROGRAM_OPTIONS_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::boost"
-    )
 endif()
 if(Boost_UNIT_TEST_FRAMEWORK_LIBRARY AND NOT TARGET Boost::unit_test_framework)
     add_library(Boost::unit_test_framework ${LIBRARY_TYPE} IMPORTED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 project(Cucumber-Cpp)
 
 option(BUILD_SHARED_LIBS        "Generate shared libraries" OFF)
-option(CUKE_USE_STATIC_BOOST    "Statically link Boost (except boost::test)" ${WIN32})
 option(CUKE_USE_STATIC_GTEST    "Statically link Google Test" ON)
 option(CUKE_ENABLE_BOOST_TEST   "Enable Boost.Test framework" ON)
 option(CUKE_ENABLE_EXAMPLES     "Build examples" OFF)
@@ -111,56 +110,11 @@ endif()
 # Boost
 #
 
-set(BOOST_MIN_VERSION "1.70")
-
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(CUKE_CORE_BOOST_LIBS system)
 if(CUKE_ENABLE_BOOST_TEST)
     # "An external test runner utility is required to link with dynamic library" (Boost User's Guide)
-    set(Boost_USE_STATIC_LIBS OFF)
     set(CMAKE_CXX_FLAGS "-DBOOST_TEST_DYN_LINK ${CMAKE_CXX_FLAGS}")
-    find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS unit_test_framework)
-endif()
-
-if(CUKE_USE_STATIC_BOOST)
-    set(Boost_USE_STATIC_LIBS ON)
-    find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS ${CUKE_CORE_BOOST_LIBS} REQUIRED)
-else()
-    set(CMAKE_CXX_FLAGS "-DBOOST_ALL_DYN_LINK ${CMAKE_CXX_FLAGS}")
-    set(Boost_USE_STATIC_LIBS OFF)
-    find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS ${CUKE_CORE_BOOST_LIBS} REQUIRED)
-endif()
-
-# Create import targets for CMake versions older than 3.5 (actually older FindBoost.cmake)
-if(Boost_USE_STATIC_LIBS)
-    set(LIBRARY_TYPE STATIC)
-else()
-    # Just because we don't ask for static doesn't mean we're not getting static
-    set(LIBRARY_TYPE UNKNOWN)
-endif()
-if(Boost_INCLUDE_DIRS AND NOT TARGET Boost::boost)
-    add_library(Boost::boost INTERFACE IMPORTED)
-    set_target_properties(Boost::boost PROPERTIES
-        "INTERFACE_INCLUDE_DIRECTORIES" "${Boost_INCLUDE_DIRS}")
-endif()
-if(Boost_SYSTEM_LIBRARY AND NOT TARGET Boost::system)
-    add_library(Boost::system ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::system PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_SYSTEM_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::boost"
-    )
-    if(Boost_USE_STATIC_LIBS)
-        set_target_properties(Boost::system PROPERTIES
-            "COMPILE_DEFINITIONS" BOOST_ERROR_CODE_HEADER_ONLY=1
-        )
-    endif()
-endif()
-if(Boost_UNIT_TEST_FRAMEWORK_LIBRARY AND NOT TARGET Boost::unit_test_framework)
-    add_library(Boost::unit_test_framework ${LIBRARY_TYPE} IMPORTED)
-    set_target_properties(Boost::unit_test_framework PROPERTIES
-        "IMPORTED_LOCATION" "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}"
-        "INTERFACE_LINK_LIBRARIES" "Boost::boost"
-    )
+    find_package(Boost 1.70 COMPONENTS unit_test_framework)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,13 +111,7 @@ endif()
 # Boost
 #
 
-if(MSVC11)
-    # Boost 1.51 fixed a bug with MSVC11
-    message(STATUS "Forcing Boost 1.51+ on MSVC11")
-    set(BOOST_MIN_VERSION "1.51")
-else()
-    set(BOOST_MIN_VERSION "1.46")
-endif()
+set(BOOST_MIN_VERSION "1.70")
 
 set(Boost_USE_STATIC_RUNTIME OFF)
 set(CUKE_CORE_BOOST_LIBS system program_options)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It relies on a few executables:
 It relies on a few libraries:
 
 * [Boost](http://www.boost.org/) 1.70.
-  Required libraries: *system* and *program_options*.
+  Required libraries: *system*.
   Optional library for Boost Test driver: *test*.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.
   Optional for the GTest driver. By default downloaded and built by CMake.
@@ -31,6 +31,7 @@ It relies on a few libraries:
   Optional for the internal test suite. By default downloaded and built by CMake.
 * [nlohmann-json](https://github.com/nlohmann/json) 3.10.5 or later.
 * [Qt 4 or 5](http://qt-project.org/). Optional for the CalcQt example and QtTest driver (only Qt 5).
+* [TCLAP](https://tclap.sourceforge.net/) 1.2.5 or later.
 
 It might work with earlier versions of the libraries, but it was not tested with them.
 See the [CI scripts](.github/workflows/run-all.yml) for details about dependency installation.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It relies on a few executables:
 
 It relies on a few libraries:
 
-* [Boost](http://www.boost.org/) 1.46 or later (1.51+ on Windows).
+* [Boost](http://www.boost.org/) 1.70.
   Required libraries: *system* and *program_options*.
   Optional library for Boost Test driver: *test*.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ It relies on a few executables:
 
 It relies on a few libraries:
 
-* [Boost](http://www.boost.org/) 1.70.
-  Required libraries: *system*.
-  Optional library for Boost Test driver: *test*.
+* [Asio](https://think-async.com/Asio/) 1.18.1 or later.
+* [Boost.Test](http://www.boost.org/) 1.70. Optional for the Boost Test driver.
 * [GTest](http://code.google.com/p/googletest/) 1.6 or later.
   Optional for the GTest driver. By default downloaded and built by CMake.
 * [GMock](http://code.google.com/p/googlemock/) 1.6 or later.

--- a/cmake/modules/FindAsio.cmake
+++ b/cmake/modules/FindAsio.cmake
@@ -1,0 +1,10 @@
+find_path(ASIO_INCLUDE_DIR asio.hpp)
+
+if (ASIO_INCLUDE_DIR)
+    set(ASIO_FOUND TRUE)
+else ()
+    set(ASIO_FOUND FALSE)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Asio REQUIRED_VARS ASIO_INCLUDE_DIR)

--- a/cmake/modules/FindTCLAP.cmake
+++ b/cmake/modules/FindTCLAP.cmake
@@ -1,0 +1,10 @@
+find_path(TCLAP_INCLUDE_DIR tclap/CmdLine.h)
+
+if (TCLAP_INCLUDE_DIR)
+    set(TCLAP_FOUND TRUE)
+else ()
+    set(TCLAP_FOUND FALSE)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(TCLAP REQUIRED_VARS TCLAP_INCLUDE_DIR)

--- a/cmake/modules/GitVersion.cmake
+++ b/cmake/modules/GitVersion.cmake
@@ -1,0 +1,29 @@
+function(git_get_version VERSION_VARIABLE)
+    find_program(GIT_EXECUTABLE git)
+
+    if(NOT GIT_EXECUTABLE)
+        message(FATAL_ERROR "Git not found. Please install Git and make sure it is in your system's PATH.")
+    endif()
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --always --dirty
+        OUTPUT_VARIABLE VERSION_STRING
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+        ERROR_VARIABLE GIT_DESCRIBE_ERROR
+        RESULT_VARIABLE GIT_DESCRIBE_RESULT
+    )
+
+    if(NOT GIT_DESCRIBE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Error running 'git describe': ${GIT_DESCRIBE_ERROR}")
+    endif()
+
+    string(LENGTH "${VERSION_STRING}" VERSION_STRING_LENGTH)
+    string(SUBSTRING "${VERSION_STRING}" 0 1 FIRST_CHARACTER)
+
+    if("${FIRST_CHARACTER}" STREQUAL "v")
+        string(SUBSTRING "${VERSION_STRING}" 1 ${VERSION_STRING_LENGTH} VERSION_STRING)
+    endif()
+
+    set(${VERSION_VARIABLE} ${VERSION_STRING} PARENT_SCOPE)
+endfunction()

--- a/include/cucumber-cpp/internal/RegistrationMacros.hpp
+++ b/include/cucumber-cpp/internal/RegistrationMacros.hpp
@@ -1,6 +1,8 @@
 #ifndef CUKE_REGISTRATIONMACROS_HPP_
 #define CUKE_REGISTRATIONMACROS_HPP_
 
+#include <boost/config/helper_macros.hpp>
+
 // ************************************************************************** //
 // **************            OBJECT NAMING MACROS              ************** //
 // ************************************************************************** //

--- a/include/cucumber-cpp/internal/RegistrationMacros.hpp
+++ b/include/cucumber-cpp/internal/RegistrationMacros.hpp
@@ -1,12 +1,6 @@
 #ifndef CUKE_REGISTRATIONMACROS_HPP_
 #define CUKE_REGISTRATIONMACROS_HPP_
 
-#if __cplusplus >= 201103L
-    #define CUKE_OVERRIDE override
-#else
-    #define CUKE_OVERRIDE
-#endif
-
 // ************************************************************************** //
 // **************            OBJECT NAMING MACROS              ************** //
 // ************************************************************************** //
@@ -27,16 +21,16 @@
 // **************                 CUKE OBJECTS                 ************** //
 // ************************************************************************** //
 
-#define CUKE_OBJECT_(class_name, parent_class, registration_fn, args)                          \
-    class class_name : public parent_class {                                                   \
-    public:                                                                                    \
-        void body() CUKE_OVERRIDE { return invokeWithArgs(*this, &class_name::bodyWithArgs); } \
-        void bodyWithArgs args;                                                                \
-                                                                                               \
-    private:                                                                                   \
-        static const int cukeRegId;                                                            \
-    };                                                                                         \
-    const int class_name ::cukeRegId = registration_fn;                                        \
+#define CUKE_OBJECT_(class_name, parent_class, registration_fn, args)                     \
+    class class_name : public parent_class {                                              \
+    public:                                                                               \
+        void body() override { return invokeWithArgs(*this, &class_name::bodyWithArgs); } \
+        void bodyWithArgs args;                                                           \
+                                                                                          \
+    private:                                                                              \
+        static const int cukeRegId;                                                       \
+    };                                                                                    \
+    const int class_name ::cukeRegId = registration_fn;                                   \
     void class_name ::bodyWithArgs args /**/
 
 #endif /* CUKE_REGISTRATIONMACROS_HPP_ */

--- a/include/cucumber-cpp/internal/RegistrationMacros.hpp
+++ b/include/cucumber-cpp/internal/RegistrationMacros.hpp
@@ -1,22 +1,25 @@
 #ifndef CUKE_REGISTRATIONMACROS_HPP_
 #define CUKE_REGISTRATIONMACROS_HPP_
 
-#include <boost/config/helper_macros.hpp>
-
 // ************************************************************************** //
 // **************            OBJECT NAMING MACROS              ************** //
 // ************************************************************************** //
+
+// from https://www.boost.org/doc/libs/1_84_0/boost/config/helper_macros.hpp
+#define CUKE_JOIN(X, Y) CUKE_DO_JOIN(X, Y)
+#define CUKE_DO_JOIN(X, Y) CUKE_DO_JOIN2(X, Y)
+#define CUKE_DO_JOIN2(X, Y) X##Y
 
 #ifndef CUKE_OBJECT_PREFIX
     #define CUKE_OBJECT_PREFIX CukeObject
 #endif
 
 #ifdef __COUNTER__
-    #define CUKE_GEN_OBJECT_NAME_ BOOST_JOIN(CUKE_OBJECT_PREFIX, __COUNTER__)
+    #define CUKE_GEN_OBJECT_NAME_ CUKE_JOIN(CUKE_OBJECT_PREFIX, __COUNTER__)
 #else
     // Use a counter to be incremented every time cucumber-cpp is included
     // in case this does not suffice (possible with multiple files only)
-    #define CUKE_GEN_OBJECT_NAME_ BOOST_JOIN(CUKE_OBJECT_PREFIX, __LINE__)
+    #define CUKE_GEN_OBJECT_NAME_ CUKE_JOIN(CUKE_OBJECT_PREFIX, __LINE__)
 #endif
 
 // ************************************************************************** //

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 
 namespace cucumber {
 namespace internal {
@@ -29,15 +29,14 @@ public:
 
 protected:
     const ProtocolHandler* protocolHandler;
-    boost::asio::io_service ios;
+    asio::io_service ios;
 
     template<typename Protocol>
     void doListen(
-        boost::asio::basic_socket_acceptor<Protocol>& acceptor,
-        const typename Protocol::endpoint& endpoint
+        asio::basic_socket_acceptor<Protocol>& acceptor, const typename Protocol::endpoint& endpoint
     );
     template<typename Protocol>
-    void doAcceptOnce(boost::asio::basic_socket_acceptor<Protocol>& acceptor);
+    void doAcceptOnce(asio::basic_socket_acceptor<Protocol>& acceptor);
     void processStream(std::iostream& stream);
 };
 
@@ -64,7 +63,7 @@ public:
     /**
      * Bind and listen to a TCP port on the given endpoint
      */
-    void listen(const boost::asio::ip::tcp::endpoint endpoint);
+    void listen(const asio::ip::tcp::endpoint endpoint);
 
     /**
      * Endpoint (IP address and port number) that this server is currently
@@ -73,15 +72,15 @@ public:
      * @throw std::system_error when not listening on any socket or
      *        the endpoint cannot be determined.
      */
-    boost::asio::ip::tcp::endpoint listenEndpoint() const;
+    asio::ip::tcp::endpoint listenEndpoint() const;
 
     void acceptOnce() override;
 
 private:
-    boost::asio::ip::tcp::acceptor acceptor;
+    asio::ip::tcp::acceptor acceptor;
 };
 
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+#if defined(ASIO_HAS_LOCAL_SOCKETS)
 /**
  * Socket server that calls a protocol handler line by line
  */
@@ -103,14 +102,14 @@ public:
      * @throw std::system_error when not listening on any socket or
      *        the endpoint cannot be determined.
      */
-    boost::asio::local::stream_protocol::endpoint listenEndpoint() const;
+    asio::local::stream_protocol::endpoint listenEndpoint() const;
 
     void acceptOnce() override;
 
     ~UnixSocketServer() override;
 
 private:
-    boost::asio::local::stream_protocol::acceptor acceptor;
+    asio::local::stream_protocol::acceptor acceptor;
 };
 #endif
 

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -31,15 +31,6 @@ protected:
     const ProtocolHandler* protocolHandler;
     boost::asio::io_service ios;
 
-#if BOOST_VERSION <= 106500
-    template<typename Protocol, typename Service>
-    void doListen(
-        boost::asio::basic_socket_acceptor<Protocol, Service>& acceptor,
-        const typename Protocol::endpoint& endpoint
-    );
-    template<typename Protocol, typename Service>
-    void doAcceptOnce(boost::asio::basic_socket_acceptor<Protocol, Service>& acceptor);
-#else
     template<typename Protocol>
     void doListen(
         boost::asio::basic_socket_acceptor<Protocol>& acceptor,
@@ -47,7 +38,6 @@ protected:
     );
     template<typename Protocol>
     void doAcceptOnce(boost::asio::basic_socket_acceptor<Protocol>& acceptor);
-#endif
     void processStream(std::iostream& stream);
 };
 

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -70,7 +70,7 @@ public:
      * Endpoint (IP address and port number) that this server is currently
      * listening on.
      *
-     * @throw boost::system::system_error when not listening on any socket or
+     * @throw std::system_error when not listening on any socket or
      *        the endpoint cannot be determined.
      */
     boost::asio::ip::tcp::endpoint listenEndpoint() const;
@@ -100,7 +100,7 @@ public:
     /**
      * Port number that this server is currently listening on.
      *
-     * @throw boost::system::system_error when not listening on any socket or
+     * @throw std::system_error when not listening on any socket or
      *        the endpoint cannot be determined.
      */
     boost::asio::local::stream_protocol::endpoint listenEndpoint() const;

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -6,9 +6,7 @@
 #include "../Scenario.hpp"
 #include "../step/StepManager.hpp"
 
-#include <boost/config.hpp>
 #include <memory>
-
 #include <list>
 
 namespace cucumber {
@@ -102,11 +100,7 @@ protected:
 
 private:
     // We're a singleton so don't allow instances
-    HookRegistrar()
-#ifndef BOOST_NO_DELETED_FUNCTIONS
-        = delete
-#endif
-        ;
+    HookRegistrar() = delete;
 };
 
 class CUCUMBER_CPP_EXPORT StepCallChain {

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -6,13 +6,8 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/config.hpp>
 #include <memory>
-
-#ifndef BOOST_NO_VARIADIC_TEMPLATES
-    #include <type_traits>
-#endif
+#include <type_traits>
 
 #include <cucumber-cpp/internal/CukeExport.hpp>
 #include "../Table.hpp"
@@ -43,10 +38,7 @@ public:
     const match_results_type& getResultSet();
     void addMatch(SingleStepMatch match);
 
-#ifndef BOOST_NO_EXPLICIT_CONVERSION_OPERATORS
-    explicit
-#endif
-    operator bool() const;
+    explicit operator bool() const;
 
 private:
     match_results_type resultSet;
@@ -139,13 +131,6 @@ protected:
     const T getInvokeArg();
     const InvokeArgs* getArgs();
 
-#ifdef BOOST_NO_VARIADIC_TEMPLATES
-    // Special case for zero arguments, only thing we bother to support on C++98
-    template<typename Derived, typename R>
-    static R invokeWithArgs(Derived& that, R (Derived::*f)()) {
-        return (that.*f)();
-    }
-#else
     template<typename Derived, typename R, typename... Args, std::size_t... N>
     static R invokeWithIndexedArgs(Derived& that, R (Derived::*f)(Args...), index_sequence<N...>) {
         return (that.*f)(that.pArgs->template getInvokeArg<typename std::decay<Args>::type>(N)...);
@@ -156,7 +141,6 @@ protected:
         that.currentArgIndex = sizeof...(Args);
         return invokeWithIndexedArgs(that, f, index_sequence_for<Args...>{});
     }
-#endif
 
 private:
     // FIXME: awful hack because of Boost::Test
@@ -188,11 +172,7 @@ protected:
 
 private:
     // We're a singleton so don't allow instances
-    StepManager()
-#ifndef BOOST_NO_DELETED_FUNCTIONS
-        = delete
-#endif
-        ;
+    StepManager() = delete;
 };
 
 static inline std::string toSourceString(const char* filePath, const int line) {

--- a/include/cucumber-cpp/internal/utils/IndexSequence.hpp
+++ b/include/cucumber-cpp/internal/utils/IndexSequence.hpp
@@ -1,11 +1,7 @@
 #ifndef CUKE_INDEXSEQ_HPP_
 #define CUKE_INDEXSEQ_HPP_
 
-#include <boost/config.hpp>
-
-#ifndef BOOST_NO_VARIADIC_TEMPLATES
-
-    #include <utility>
+#include <utility>
 
 namespace cucumber {
 namespace internal {
@@ -15,7 +11,5 @@ using ::std::index_sequence_for;
 
 }
 }
-
-#endif /* !BOOST_NO_VARIADIC_TEMPLATES */
 
 #endif /* CUKE_INDEXSEQ_HPP_ */

--- a/include/cucumber-cpp/internal/utils/IndexSequence.hpp
+++ b/include/cucumber-cpp/internal/utils/IndexSequence.hpp
@@ -5,46 +5,13 @@
 
 #ifndef BOOST_NO_VARIADIC_TEMPLATES
 
-    #if __cplusplus < 201402L && !(_MSC_VER > 1800)
-        #include <cstddef> // for std::size_t
-    #else
-        #include <utility>
-    #endif
+    #include <utility>
 
 namespace cucumber {
 namespace internal {
 
-    #if __cplusplus < 201402L && !(_MSC_VER > 1800)
-// Based on https://stackoverflow.com/questions/17424477/implementation-c14-make-integer-sequence
-
-template<std::size_t... N>
-struct index_sequence {
-    typedef index_sequence type;
-};
-
-template<typename Seq1, typename Seq2>
-struct concat_index_sequence;
-
-template<std::size_t... N1, std::size_t... N2>
-struct concat_index_sequence<index_sequence<N1...>, index_sequence<N2...>>
-    : public index_sequence<N1..., (sizeof...(N1) + N2)...> {};
-
-template<std::size_t N>
-struct make_index_sequence : public concat_index_sequence<
-                                 typename make_index_sequence<N / 2>::type,
-                                 typename make_index_sequence<N - N / 2>::type> {};
-
-template<>
-struct make_index_sequence<0> : public index_sequence<> {};
-template<>
-struct make_index_sequence<1> : public index_sequence<0> {};
-
-template<typename... Ts>
-using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
-    #else
 using ::std::index_sequence;
 using ::std::index_sequence_for;
-    #endif
 
 }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(GenerateExportHeader)
 
 find_package(nlohmann_json 3.10.5 REQUIRED)
+find_package(Asio REQUIRED)
 find_package(TCLAP REQUIRED)
 include(../cmake/modules/GitVersion.cmake)
 
@@ -107,8 +108,6 @@ foreach(TARGET
             $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
     )
     target_link_libraries(${TARGET}
-        PUBLIC
-            Boost::boost
         PRIVATE
             ${CUKE_EXTRA_PRIVATE_LIBRARIES}
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(GenerateExportHeader)
 
 find_package(nlohmann_json 3.10.5 REQUIRED)
+include(../cmake/modules/GitVersion.cmake)
 
 set(CUKE_SOURCES
     drivers/GenericDriver.cpp
@@ -122,6 +123,12 @@ foreach(TARGET
         )
     endif(MINGW)
 endforeach()
+
+git_get_version(CUKE_VERSION)
+message(STATUS "Version: ${CUKE_VERSION}")
+target_compile_definitions(cucumber-cpp PRIVATE
+    CUKE_VERSION="${CUKE_VERSION}"
+)
 
 target_link_libraries(cucumber-cpp
     PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(GenerateExportHeader)
 
 find_package(nlohmann_json 3.10.5 REQUIRED)
+find_package(TCLAP REQUIRED)
 include(../cmake/modules/GitVersion.cmake)
 
 set(CUKE_SOURCES
@@ -128,11 +129,6 @@ git_get_version(CUKE_VERSION)
 message(STATUS "Version: ${CUKE_VERSION}")
 target_compile_definitions(cucumber-cpp PRIVATE
     CUKE_VERSION="${CUKE_VERSION}"
-)
-
-target_link_libraries(cucumber-cpp
-    PRIVATE
-        Boost::program_options
 )
 
 include(GNUInstallDirs)

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -15,17 +15,10 @@ SocketServer::SocketServer(const ProtocolHandler* protocolHandler) :
     ios() {
 }
 
-#if BOOST_VERSION <= 106500
-template<typename Protocol, typename Service>
-void SocketServer::doListen(
-    basic_socket_acceptor<Protocol, Service>& acceptor, const typename Protocol::endpoint& endpoint
-) {
-#else
 template<typename Protocol>
 void SocketServer::doListen(
     basic_socket_acceptor<Protocol>& acceptor, const typename Protocol::endpoint& endpoint
 ) {
-#endif
     if (acceptor.is_open())
         throw boost::system::system_error(boost::asio::error::already_open);
     acceptor.open(endpoint.protocol());
@@ -34,13 +27,8 @@ void SocketServer::doListen(
     acceptor.listen(1);
 }
 
-#if BOOST_VERSION <= 106500
-template<typename Protocol, typename Service>
-void SocketServer::doAcceptOnce(basic_socket_acceptor<Protocol, Service>& acceptor) {
-#else
 template<typename Protocol>
 void SocketServer::doAcceptOnce(basic_socket_acceptor<Protocol>& acceptor) {
-#endif
     typename Protocol::iostream stream;
     acceptor.accept(*stream.rdbuf());
     processStream(stream);

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -20,7 +20,7 @@ void SocketServer::doListen(
     basic_socket_acceptor<Protocol>& acceptor, const typename Protocol::endpoint& endpoint
 ) {
     if (acceptor.is_open())
-        throw boost::system::system_error(boost::asio::error::already_open);
+        throw std::system_error(asio::error::already_open);
     acceptor.open(endpoint.protocol());
     acceptor.set_option(typename Protocol::acceptor::reuse_address(true));
     acceptor.bind(endpoint);

--- a/src/drivers/BoostDriver.cpp
+++ b/src/drivers/BoostDriver.cpp
@@ -45,11 +45,7 @@ public:
     // Formatter
     void log_start(std::ostream&, counter_t /*test_cases_amount*/) override{};
     void log_finish(std::ostream&) override{};
-#if BOOST_VERSION >= 107000
     void log_build_info(std::ostream&, bool /*log_build_info*/) override{};
-#else
-    void log_build_info(std::ostream&) override{};
-#endif
 
     void test_unit_start(std::ostream&, test_unit const& /*tu*/) override{};
     void test_unit_finish(std::ostream&, test_unit const& /*tu*/, unsigned long /*elapsed*/)
@@ -67,17 +63,10 @@ public:
 
     void entry_context_start(std::ostream&, log_level /*l*/) override {
     }
-#if BOOST_VERSION >= 106500
     void log_entry_context(std::ostream&, log_level /*l*/, const_string /*value*/) override {
     }
     void entry_context_finish(std::ostream&, log_level /*l*/) override {
     }
-#else
-    void log_entry_context(std::ostream&, const_string /*value*/) override {
-    }
-    void entry_context_finish(std::ostream&) override {
-    }
-#endif
 
 private:
     std::stringstream description;
@@ -121,9 +110,7 @@ void BoostStep::initBoostTest() {
     char dummyArg[] = "dummy";
     char* argv[] = {dummyArg};
     framework::init(&boost_test_init, argc, argv);
-#if BOOST_VERSION >= 105900
     framework::finalize_setup_phase();
-#endif
 
     logInterceptor = new CukeBoostLogInterceptor;
     ::boost::unit_test::unit_test_log.set_formatter(logInterceptor);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ void acceptWireProtocol(
     JsonWireMessageCodec wireCodec;
     WireProtocolHandler protocolHandler(wireCodec, cukeEngine);
     std::unique_ptr<SocketServer> server;
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+#if defined(ASIO_HAS_LOCAL_SOCKETS)
     if (!unixPath.empty()) {
         UnixSocketServer* const unixServer = new UnixSocketServer(&protocolHandler);
         server.reset(unixServer);
@@ -31,9 +31,7 @@ void acceptWireProtocol(
     {
         TCPSocketServer* const tcpServer = new TCPSocketServer(&protocolHandler);
         server.reset(tcpServer);
-        tcpServer->listen(
-            boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(host), port)
-        );
+        tcpServer->listen(asio::ip::tcp::endpoint(asio::ip::address::from_string(host), port));
         if (verbose)
             std::clog << "Listening on " << tcpServer->listenEndpoint() << std::endl;
     }
@@ -60,7 +58,7 @@ int CUCUMBER_CPP_EXPORT main(int argc, char** argv) {
     );
     cmd.add(portArg);
 
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+#if defined(ASIO_HAS_LOCAL_SOCKETS)
     TCLAP::ValueArg<std::string> unixArg(
         "u",
         "unix",
@@ -77,7 +75,7 @@ int CUCUMBER_CPP_EXPORT main(int argc, char** argv) {
     std::string unixPath;
     std::string listenHost = listenArg.getValue();
     int port = portArg.getValue();
-#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+#if defined(ASIO_HAS_LOCAL_SOCKETS)
     unixPath = unixArg.getValue();
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ int CUCUMBER_CPP_EXPORT main(int argc, char** argv) {
     boost::program_options::options_description optionDescription("Allowed options");
     optionDescription.add_options()("help,h", "help for cucumber-cpp")(
         "verbose,v", "verbose output"
+    )("version", "version of cucumber-cpp"
     )("listen,l", value<std::string>(), "listening address of wireserver"
     )("port,p",
       value<int>(),
@@ -66,6 +67,11 @@ int CUCUMBER_CPP_EXPORT main(int argc, char** argv) {
     if (optionVariableMap.count("help")) {
         std::cerr << optionDescription << std::endl;
         exit(1);
+    }
+
+    if (optionVariableMap.count("version")) {
+        std::cout << CUKE_VERSION << std::endl;
+        exit(0);
     }
 
     std::string listenHost("127.0.0.1");

--- a/tests/integration/drivers/BoostDriverTest.cpp
+++ b/tests/integration/drivers/BoostDriverTest.cpp
@@ -26,7 +26,6 @@ THEN(PENDING_MATCHER_2) {
 
 using namespace cucumber::internal;
 
-#if BOOST_VERSION >= 105900
 namespace boost {
 namespace unit_test {
 namespace framework {
@@ -36,7 +35,6 @@ bool is_initialized() {
 }
 }
 }
-#endif
 
 class BoostStepDouble : public BoostStep {
 public:

--- a/tests/unit/CukeCommandsTest.cpp
+++ b/tests/unit/CukeCommandsTest.cpp
@@ -3,8 +3,6 @@
 #include <cucumber-cpp/internal/step/StepMacros.hpp>
 #include "utils/CukeCommandsFixture.hpp"
 
-#include <boost/config.hpp>
-
 using namespace cucumber::internal;
 
 using std::string;
@@ -77,7 +75,6 @@ public:
     }
 };
 
-#ifndef BOOST_NO_VARIADIC_TEMPLATES
 class CheckAllParametersWithFuncArgs : public CheckAllParameters {
 public:
     void bodyWithArgs(
@@ -101,7 +98,6 @@ TEST_F(CukeCommandsTest, invokeHandlesParametersWithFuncArgs) {
     // The real test is in TestClass::body()
     runStepBodyTest<CheckAllParametersWithFuncArgs>();
 }
-#endif
 
 TEST_F(CukeCommandsTest, matchesCorrectly) {
     addStepWithMatcher(STATIC_MATCHER);


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove all dependencies to boost (except for boost test).

## Details

Remove macros provided by boost to handle compilers that don't support the needed features. All major compilers now support the features we need.

Additional changes:
- use TCLAP library instead of boost::program_options
- throw std::system_error instead of boost::system::system_error
- use non-boost version of asio

## Motivation and Context

Boost is a bit heavy and most functionality is no longer needed. With this changes, cucumber-cpp does not need boost anymore.

## How Has This Been Tested?

Automated tests and own project.

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

Boost is no longer a dependency but TCLAP and asio. Consumer of cucumber-cpp should not need to change their code, only the dependencies.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
