### PR TITLE
fix flaky QtTestDriver test

### DIFF
--- a/src/drivers/QtTestDriver.cpp
+++ b/src/drivers/QtTestDriver.cpp
@@ -14,12 +14,10 @@ const InvokeResult QtTestStep::invokeStepBody() {
     }
     file.close();
 
-    QtTestObject testObject(this);
-    int returnValue = QTest::qExec(
-        &testObject,
-        QStringList() << "test"
-                      << "-o" << file.fileName()
-    );
+    QtTestObject testObject{this};
+    const QStringList args{"test", "-o", file.fileName() + ",tap"};
+    int returnValue = QTest::qExec(&testObject, args);
+
     if (returnValue == 0) {
         return InvokeResult::success();
     } else {


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

The test output contained timing information, leading to a flaky test. Fixed by using the TAP output, that doesn't contain timing information.

## Details

See https://doc.qt.io/qt-6/qtest-overview.html#logging-options for more information.

## Motivation and Context

Solves the issue from this PR: https://github.com/cucumber/cucumber-cpp/pull/293#issuecomment-2049850379

## How Has This Been Tested?

The fix itself is only manually verified. The code has automated tests, hence pretty sure to not have added a regression.

**Note**: the log output changed, but it should only affect developers reading the log.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
