### PR TITLE
allow compilation without git or when git fails

### DIFF
--- a/cmake/modules/GitVersion.cmake
+++ b/cmake/modules/GitVersion.cmake
@@ -1,8 +1,12 @@
 function(git_get_version VERSION_VARIABLE)
+    string(TIMESTAMP TODAY "%Y.%m.%d")
+    set(${VERSION_VARIABLE} "0.0.0+${TODAY}" PARENT_SCOPE)
+
     find_program(GIT_EXECUTABLE git)
 
     if(NOT GIT_EXECUTABLE)
-        message(FATAL_ERROR "Git not found. Please install Git and make sure it is in your system's PATH.")
+        message(WARNING "Git not found, using fallback version.")
+        return()
     endif()
 
     execute_process(
@@ -15,7 +19,9 @@ function(git_get_version VERSION_VARIABLE)
     )
 
     if(NOT GIT_DESCRIBE_RESULT EQUAL 0)
-        message(FATAL_ERROR "Error running 'git describe': ${GIT_DESCRIBE_ERROR}")
+        message(INFO "Error running 'git describe': ${GIT_DESCRIBE_ERROR}")
+        message(WARNING "Git failed, using fallback version.")
+        return()
     endif()
 
     string(LENGTH "${VERSION_STRING}" VERSION_STRING_LENGTH)


### PR DESCRIPTION
## Summary

Allow compilation without git or when git fails.

## Details

This happens when the code is downloaded as source archive. This does not contain the git repository, hence the git version script fails. 

Now the version 0.0.0+YEAR.MONTH.DAY is used when we fail to get the version from git.

## Motivation and Context

One problem mentioned in #295.

## How Has This Been Tested?

Manually by removing the .git directory and adding it back again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
