### PR TITLE
only treat compilation warnings as error in CI

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -57,6 +57,7 @@ jobs:
 
     - name: build
       run: |
+        export CXXFLAGS=-Werror
         cmake -E make_directory build
         cmake -E chdir build cmake \
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp-compiler }} \

--- a/.github/workflows/qt5.yml
+++ b/.github/workflows/qt5.yml
@@ -51,6 +51,7 @@ jobs:
 
     - name: build
       run: |
+        export CXXFLAGS=-Werror
         cmake -E make_directory build
         cmake -E chdir build cmake \
           -G Ninja \
@@ -60,7 +61,7 @@ jobs:
           -DCUKE_ENABLE_EXAMPLES=on \
           -DCUKE_TESTS_UNIT=on \
           ..
-        cmake --build build --parallel
+        cmake --build build --parallel --verbose
 
     - name: unit tests
       run: |

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -56,6 +56,7 @@ jobs:
 
     - name: build and run
       run: |
+        export CXXFLAGS=-Werror
         ./run-linux.sh
 
     - name: code coverage summary report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 #
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Werror -Wall -Wextra -Wsuggest-override ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -Wextra -Wsuggest-override ${CMAKE_CXX_FLAGS}")
     # TODO: A better fix should handle ld's --as-needed flag
     if(UNIX AND NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker '--no-as-needed'")

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -15,7 +15,7 @@ cmake -E chdir build cmake \
     -DCUKE_TESTS_UNIT=on \
     -DCUKE_CODE_COVERAGE=on \
     ..
-cmake --build build --parallel
+cmake --build build --parallel --verbose
 
 #
 # Run tests


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

All warnings are treated as errors. This may lead to problems when using a different compiler version or during development.

## Details

Now the warnings are only treated as errors in the CI.

## Motivation and Context

Mentioned in #295.

## How Has This Been Tested?

Manually by inspecting the actually used flags when Cmake is building the software. On the CI and locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [x] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [x] My branch has been rebased to main, keeping only relevant commits.
