### PR TITLE
fix: support asio 1.33

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 if(CUKE_STRICT)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DASIO_NO_DEPRECATED")
 endif()
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
     const ProtocolHandler* protocolHandler;
-    asio::io_service ios;
+    asio::io_context ios;
 
     template<typename Protocol>
     void doListen(

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -23,8 +23,9 @@ void SocketServer::doListen(
 
 template<typename Protocol>
 void SocketServer::doAcceptOnce(asio::basic_socket_acceptor<Protocol>& acceptor) {
-    typename Protocol::iostream stream;
-    acceptor.accept(*stream.rdbuf());
+    typename Protocol::socket socket(ios);
+    acceptor.accept(socket);
+    typename Protocol::iostream stream(std::move(socket));
     processStream(stream);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ void acceptWireProtocol(
     {
         TCPSocketServer* const tcpServer = new TCPSocketServer(&protocolHandler);
         server.reset(tcpServer);
-        tcpServer->listen(asio::ip::tcp::endpoint(asio::ip::address::from_string(host), port));
+        tcpServer->listen(asio::ip::tcp::endpoint(asio::ip::make_address(host), port));
         if (verbose)
             std::clog << "Listening on " << tcpServer->listenEndpoint() << std::endl;
     }

--- a/tests/integration/WireServerTest.cpp
+++ b/tests/integration/WireServerTest.cpp
@@ -141,7 +141,7 @@ protected:
 
     SocketServer* createListeningServer() override {
         server.reset(new TCPSocketServer(&protocolHandler));
-        server->listen(asio::ip::tcp::endpoint(asio::ip::address::from_string("127.0.0.1"), 0));
+        server->listen(asio::ip::tcp::endpoint(asio::ip::make_address("127.0.0.1"), 0));
         return server.get();
     }
 


### PR DESCRIPTION
Asio changed  `io_service`to `io_context` since 1.33


## Summary

Since Asio 1.33, [`io_service` is changed to `io_context`](https://github.com/widelands/widelands/issues/6663) , so this change is needed to support newer asio version.

## Details

Changed the code where `io_service` is used to `io_context`. Tested this bug exists by first introducing a flag that made the build fail in this #311

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

`cmake --build build --target test` has been run succesfully, so all the unit test is done.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [x] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [ ] I have verified whether my change requires changes to the documentation
- [x] My change either requires no documentation change or I've updated the documentation accordingly.
- [ ] My branch has been rebased to main, keeping only relevant commits.
